### PR TITLE
Fixed the versions for the FOSUserBundle advisory

### DIFF
--- a/friendsofsymfony/user-bundle/CVE-2013-5750.yaml
+++ b/friendsofsymfony/user-bundle/CVE-2013-5750.yaml
@@ -3,8 +3,8 @@ link:      http://symfony.com/blog/cve-2013-5750-security-issue-in-fosuserbundle
 cve:       CVE-2013-5750
 branches:
     1.2.x:
-        time:     2012-09-23 10:11:26
-        versions: [>=1.2.0,<1.2.99]
+        time:     2012-09-23 13:43:36
+        versions: [>=1.2.0,<1.2.5]
     1.3.x:
         time:     2012-09-23 10:11:26
         versions: [>=1.3.0,<1.3.3]


### PR DESCRIPTION
This fixes the impacted versions.

I also found that the time you used in this files are using the Europe/Paris timezone, not UTC. Is it expected or is it a mistake ?
Anyway, I used the same timezone when updating it.
