### PR TITLE
Added CVE-2014-2383 security advisory

### DIFF
--- a/dompdf/dompdf/CVE-2014-2383.yaml
+++ b/dompdf/dompdf/CVE-2014-2383.yaml
@@ -1,0 +1,8 @@
+title:     Arbitrary file read in dompdf
+link:      https://www.portcullis-security.com/security-research-and-downloads/security-advisories/cve-2014-2383/
+cve:       CVE-2014-2383
+branches:
+    0.6.x:
+        time:     2014-03-10 21:57:58
+        versions: [>=0.6.0,<0.6.1]
+reference: composer://dompdf/dompdf


### PR DESCRIPTION
Vulnerability: Arbitrary file read in dompdf
Vendor: dompdf
Product: dompdf
CVE: CVE-2014-2383
Affected version: v0.6.0
Fixed version:  v0.6.1
