### PR TITLE
Added ZF2014-04 advisory

### DIFF
--- a/zendframework/zendframework1/ZF2014-04.yaml
+++ b/zendframework/zendframework1/ZF2014-04.yaml
@@ -1,0 +1,8 @@
+title:     Potential SQL injection in the ORDER implementation of Zend_Db_Select
+link:      http://framework.zend.com/security/advisory/ZF2014-04
+cve:       ~
+branches:
+    1.12.x:
+        time:     2014-06-11 13:46:00
+        versions: [>=1.12.0,<1.12.7]
+reference: composer://zendframework/zendframework1


### PR DESCRIPTION
Vulnerability: Potential SQL injection in the ORDER implementation of Zend_Db_Select (ZF2014-04)
Vendor/product: zendframework/zendframework1
CVE: none
Affected versions: v1.12.0 up to v1.12.6
Fixed version: v1.12.7
References: http://framework.zend.com/security/advisory/ZF2014-04, https://github.com/zendframework/zf1/commit/da09186c60b9168520e994af4253fba9c19c2b3d
