### PR TITLE
Add ZF2015-02

### DIFF
--- a/zendframework/zend-db/ZF2015-02.yaml
+++ b/zendframework/zend-db/ZF2015-02.yaml
@@ -1,0 +1,17 @@
+title:     Potential SQL injection in PostgreSQL Zend\Db adapter
+link:      http://framework.zend.com/security/advisory/ZF2015-02
+cve:       CVE-2015-0270
+branches:
+    2.0.x:
+        time:     2015-02-18 19:15:09
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2015-02-18 19:15:09
+        versions: [>=2.1.0,<2.1.99]
+    2.2.x:
+        time:     2015-02-18 19:15:09
+        versions: [>=2.2.0,<2.2.10]
+    2.3.x:
+        time:     2015-02-18 19:15:09
+        versions: [>=2.3.0,<2.3.5]
+reference: composer://zendframework/zend-db

--- a/zendframework/zend-session/ZF2015-01.yaml
+++ b/zendframework/zend-session/ZF2015-01.yaml
@@ -3,15 +3,15 @@ link:      http://framework.zend.com/security/advisory/ZF2015-01
 cve:       ~
 branches:
     2.0.x:
-        time:     2014-01-14 22:00:00
+        time:     2015-01-14 22:00:00
         versions: [>=2.0.0,<2.0.99]
     2.1.x:
-        time:     2014-01-14 22:00:00
+        time:     2015-01-14 22:00:00
         versions: [>=2.1.0,<2.1.99]
     2.2.x:
-        time:     2014-01-14 22:00:00
+        time:     2015-01-14 22:00:00
         versions: [>=2.2.0,<2.2.9]
     2.3.x:
-        time:     2014-01-14 22:00:00
+        time:     2015-01-14 22:00:00
         versions: [>=2.3.0,<2.3.4]
 reference: composer://zendframework/zend-session


### PR DESCRIPTION
All ZendFramework files name uses their internal ID name, so I went for it.
Please, do tell if ZF2015-02.yaml should be renamed as CVE-2015-0270.yaml.