### PR TITLE
Review last ZF issues

### DIFF
--- a/zendframework/zend-db/ZF2014-06.yaml
+++ b/zendframework/zend-db/ZF2014-06.yaml
@@ -1,0 +1,17 @@
+title:     SQL injection vector when manually quoting values for sqlsrv extension, using null byte
+link:      http://framework.zend.com/security/advisory/ZF2014-06
+cve:       CVE-2014-8089
+branches:
+    2.0.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.1.0,<2.1.99]
+    2.2.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.2.0,<2.2.8]
+    2.3.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.3.0,<2.3.3]
+reference: composer://zendframework/zend-db

--- a/zendframework/zend-db/ZF2015-02.yaml
+++ b/zendframework/zend-db/ZF2015-02.yaml
@@ -2,6 +2,12 @@ title:     Potential SQL injection in PostgreSQL Zend\Db adapter
 link:      http://framework.zend.com/security/advisory/ZF2015-02
 cve:       CVE-2015-0270
 branches:
+    2.0.x:
+        time:     2015-02-18 19:15:09
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2015-02-18 19:15:09
+        versions: [>=2.1.0,<2.1.99]
     2.2.x:
         time:     2015-02-18 19:15:09
         versions: [>=2.2.0,<2.2.10]

--- a/zendframework/zend-ldap/ZF2014-05.yaml
+++ b/zendframework/zend-ldap/ZF2014-05.yaml
@@ -1,0 +1,17 @@
+title:     Anonymous authentication in ldap_bind() function of PHP, using null byte
+link:      http://framework.zend.com/security/advisory/ZF2014-05
+cve:       CVE-2014-8088
+branches:
+    2.0.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.1.0,<2.1.99]
+    2.2.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.2.0,<2.2.8]
+    2.3.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.3.0,<2.3.3]
+reference: composer://zendframework/zend-ldap

--- a/zendframework/zend-session/ZF2015-01.yaml
+++ b/zendframework/zend-session/ZF2015-01.yaml
@@ -2,6 +2,12 @@ title:     Session validation vulnerability
 link:      http://framework.zend.com/security/advisory/ZF2015-01
 cve:       ~
 branches:
+    2.0.x:
+        time:     2015-01-14 22:00:00
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2015-01-14 22:00:00
+        versions: [>=2.1.0,<2.1.99]
     2.2.x:
         time:     2015-01-14 22:00:00
         versions: [>=2.2.0,<2.2.9]

--- a/zendframework/zendframework/ZF2014-05.yaml
+++ b/zendframework/zendframework/ZF2014-05.yaml
@@ -2,6 +2,12 @@ title:     Anonymous authentication in ldap_bind() function of PHP, using null b
 link:      http://framework.zend.com/security/advisory/ZF2014-05
 cve:       ~
 branches:
+    2.0.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.1.0,<2.1.99]
     2.2.x:
         time:     2014-09-16 22:00:00
         versions: [>=2.2.0,<2.2.8]

--- a/zendframework/zendframework/ZF2014-05.yaml
+++ b/zendframework/zendframework/ZF2014-05.yaml
@@ -1,6 +1,6 @@
 title:     Anonymous authentication in ldap_bind() function of PHP, using null byte
 link:      http://framework.zend.com/security/advisory/ZF2014-05
-cve:       ~
+cve:       CVE-2014-8088
 branches:
     2.0.x:
         time:     2014-09-16 22:00:00

--- a/zendframework/zendframework/ZF2014-06.yaml
+++ b/zendframework/zendframework/ZF2014-06.yaml
@@ -1,6 +1,6 @@
 title:     SQL injection vector when manually quoting values for sqlsrv extension, using null byte
 link:      http://framework.zend.com/security/advisory/ZF2014-06
-cve:       ~
+cve:       CVE-2014-8089
 branches:
     2.0.x:
         time:     2014-09-16 22:00:00

--- a/zendframework/zendframework/ZF2014-06.yaml
+++ b/zendframework/zendframework/ZF2014-06.yaml
@@ -2,6 +2,12 @@ title:     SQL injection vector when manually quoting values for sqlsrv extensio
 link:      http://framework.zend.com/security/advisory/ZF2014-06
 cve:       ~
 branches:
+    2.0.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2014-09-16 22:00:00
+        versions: [>=2.1.0,<2.1.99]
     2.2.x:
         time:     2014-09-16 22:00:00
         versions: [>=2.2.0,<2.2.8]

--- a/zendframework/zendframework/ZF2015-01.yaml
+++ b/zendframework/zendframework/ZF2015-01.yaml
@@ -2,6 +2,12 @@ title:     Session validation vulnerability
 link:      http://framework.zend.com/security/advisory/ZF2015-01
 cve:       ~
 branches:
+    2.0.x:
+        time:     2015-01-14 22:00:00
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2015-01-14 22:00:00
+        versions: [>=2.1.0,<2.1.99]
     2.2.x:
         time:     2015-01-14 22:00:00
         versions: [>=2.2.0,<2.2.9]

--- a/zendframework/zendframework/ZF2015-02.yaml
+++ b/zendframework/zendframework/ZF2015-02.yaml
@@ -2,6 +2,12 @@ title:     Potential SQL injection in PostgreSQL Zend\Db adapter
 link:      http://framework.zend.com/security/advisory/ZF2015-02
 cve:       CVE-2015-0270
 branches:
+    2.0.x:
+        time:     2015-02-18 19:15:09
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2015-02-18 19:15:09
+        versions: [>=2.1.0,<2.1.99]
     2.2.x:
         time:     2015-02-18 19:15:09
         versions: [>=2.2.0,<2.2.10]

--- a/zendframework/zendframework1/ZF2014-05.yaml
+++ b/zendframework/zendframework1/ZF2014-05.yaml
@@ -1,6 +1,6 @@
 title:     Anonymous authentication in ldap_bind() function of PHP, using null byte
 link:      http://framework.zend.com/security/advisory/ZF2014-05
-cve:       ~
+cve:       CVE-2014-8088
 branches:
     1.12.x:
         time:     2014-09-16 22:00:00

--- a/zendframework/zendframework1/ZF2014-06.yaml
+++ b/zendframework/zendframework1/ZF2014-06.yaml
@@ -1,6 +1,6 @@
 title:     SQL injection vector when manually quoting values for sqlsrv extension, using null byte
 link:      http://framework.zend.com/security/advisory/ZF2014-06
-cve:       ~
+cve:       CVE-2014-8089
 branches:
     1.12.x:
         time:     2014-09-16 22:00:00


### PR DESCRIPTION
@stof [noticed](https://github.com/FriendsOfPHP/security-advisories/pull/55#discussion_r26372431) my last clean up was too overwhelming, so I reverted it (except for ZF2015-03 as accurately [pointed](https://github.com/FriendsOfPHP/security-advisories/pull/55#discussion_r26327553) by @xabbuh).

This is a revert of the offending changes, with more CVE and components documented for theses issues.