### PR TITLE
Fix affected versions of symfony / http-foundation for CVE-2015-2309

### DIFF
--- a/symfony/http-foundation/CVE-2015-2309.yaml
+++ b/symfony/http-foundation/CVE-2015-2309.yaml
@@ -22,5 +22,5 @@ branches:
         versions: [>=2.5.0,<2.5.11]
     2.6.x:
         time:     2015-04-01 18:55:26
-        versions: [>=2.5.0,<2.6.6]
+        versions: [>=2.6.0,<2.6.6]
 reference: composer://symfony/http-foundation

--- a/symfony/symfony/CVE-2015-2309.yaml
+++ b/symfony/symfony/CVE-2015-2309.yaml
@@ -22,5 +22,5 @@ branches:
         versions: [>=2.5.0,<2.5.11]
     2.6.x:
         time:     2015-04-01 18:55:26
-        versions: [>=2.5.0,<2.6.6]
+        versions: [>=2.6.0,<2.6.6]
 reference: composer://symfony/symfony


### PR DESCRIPTION
The database incorrectly reports version 2.5.11 as affected, but that version has been fixed.
Check comments on http://symfony.com/blog/cve-2015-2309-unsafe-methods-in-the-request-class