### PR TITLE
Add ZF2015-04/CVE-2015-3154 about zendframework

### DIFF
--- a/zendframework/zend-http/ZF2015-04.yaml
+++ b/zendframework/zend-http/ZF2015-04.yaml
@@ -1,0 +1,17 @@
+title:     Potential CRLF injection attacks in mail and HTTP headers
+link:      http://framework.zend.com/security/advisory/ZF2015-04
+cve:       CVE-2015-3154
+branches:
+    2.0.x:
+        time:     2015-05-07 08:53:42
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2015-05-07 08:53:42
+        versions: [>=2.1.0,<2.1.99]
+    2.3.x:
+        time:     2015-05-07 08:16:34
+        versions: [>=2.3.0,<2.3.8]
+    2.4.x:
+        time:     2015-05-07 08:53:42
+        versions: [>=2.4.0,<2.4.1]
+reference: composer://zendframework/zend-http

--- a/zendframework/zend-mail/ZF2015-04.yaml
+++ b/zendframework/zend-mail/ZF2015-04.yaml
@@ -1,0 +1,17 @@
+title:     Potential CRLF injection attacks in mail and HTTP headers
+link:      http://framework.zend.com/security/advisory/ZF2015-04
+cve:       CVE-2015-3154
+branches:
+    2.0.x:
+        time:     2015-05-07 08:53:42
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2015-05-07 08:53:42
+        versions: [>=2.1.0,<2.1.99]
+    2.3.x:
+        time:     2015-05-07 08:16:34
+        versions: [>=2.3.0,<2.3.8]
+    2.4.x:
+        time:     2015-05-07 08:53:42
+        versions: [>=2.4.0,<2.4.1]
+reference: composer://zendframework/zend-mail

--- a/zendframework/zendframework/ZF2015-04.yaml
+++ b/zendframework/zendframework/ZF2015-04.yaml
@@ -1,0 +1,17 @@
+title:     Potential CRLF injection attacks in mail and HTTP headers
+link:      http://framework.zend.com/security/advisory/ZF2015-04
+cve:       CVE-2015-3154
+branches:
+    2.0.x:
+        time:     2015-05-07 08:53:42
+        versions: [>=2.0.0,<2.0.99]
+    2.1.x:
+        time:     2015-05-07 08:53:42
+        versions: [>=2.1.0,<2.1.99]
+    2.3.x:
+        time:     2015-05-07 08:16:34
+        versions: [>=2.3.0,<2.3.8]
+    2.4.x:
+        time:     2015-05-07 08:53:42
+        versions: [>=2.4.0,<2.4.1]
+reference: composer://zendframework/zendframework


### PR DESCRIPTION
Maybe @Ocramius could ack this proposal? After a quick look, I believe ZF1 is also partly affected, is a fix also on its way, should we document zendframework/zendframework1 as affected?