### PR TITLE
Create CVE-2015-3397 for yii2 and extensions

### DIFF
--- a/yiisoft/yii2-bootstrap/CVE-2015-3397.yaml
+++ b/yiisoft/yii2-bootstrap/CVE-2015-3397.yaml
@@ -1,0 +1,8 @@
+title:     JSON Data encoded for use in HTML was not safe to use in IE6/IE7, possible XSS attacks
+link:      http://www.yiiframework.com/news/86/yii-2-0-4-is-released/
+cve:       CVE-2015-3397
+branches:
+    2.0.x:
+        time:     2015-05-10 03:43:16
+        versions: [<2.0.4]
+reference: composer://yiisoft/yii2-bootstrap

--- a/yiisoft/yii2-dev/CVE-2015-3397.yaml
+++ b/yiisoft/yii2-dev/CVE-2015-3397.yaml
@@ -1,0 +1,8 @@
+title:     JSON Data encoded for use in HTML was not safe to use in IE6/IE7, possible XSS attacks
+link:      http://www.yiiframework.com/news/86/yii-2-0-4-is-released/
+cve:       CVE-2015-3397
+branches:
+    2.0.x:
+        time:     2015-05-10 03:38:17
+        versions: [<2.0.4]
+reference: composer://yiisoft/yii2-dev

--- a/yiisoft/yii2-gii/CVE-2015-3397.yaml
+++ b/yiisoft/yii2-gii/CVE-2015-3397.yaml
@@ -1,0 +1,8 @@
+title:     JSON Data encoded for use in HTML was not safe to use in IE6/IE7, possible XSS attacks
+link:      http://www.yiiframework.com/news/86/yii-2-0-4-is-released/
+cve:       CVE-2015-3397
+branches:
+    2.0.x:
+        time:     2015-05-10 03:41:39
+        versions: [<2.0.4]
+reference: composer://yiisoft/yii2-gii

--- a/yiisoft/yii2-jui/CVE-2015-3397.yaml
+++ b/yiisoft/yii2-jui/CVE-2015-3397.yaml
@@ -1,0 +1,8 @@
+title:     JSON Data encoded for use in HTML was not safe to use in IE6/IE7, possible XSS attacks
+link:      http://www.yiiframework.com/news/86/yii-2-0-4-is-released/
+cve:       CVE-2015-3397
+branches:
+    2.0.x:
+        time:     2015-05-10 03:58:01
+        versions: [<2.0.4]
+reference: composer://yiisoft/yii2-jui

--- a/yiisoft/yii2/CVE-2015-3397.yaml
+++ b/yiisoft/yii2/CVE-2015-3397.yaml
@@ -1,0 +1,8 @@
+title:     JSON Data encoded for use in HTML was not safe to use in IE6/IE7, possible XSS attacks
+link:      http://www.yiiframework.com/news/86/yii-2-0-4-is-released/
+cve:       CVE-2015-3397
+branches:
+    2.0.x:
+        time:     2015-05-10 03:38:17
+        versions: [<2.0.4]
+reference: composer://yiisoft/yii2


### PR DESCRIPTION
Affected packages:

- yiisoft/yii2 `<2.0.4`
- yiisoft/yii2-dev `<2.0.4`
- yiisoft/yii2-bootstrap `<2.0.4`
- yiisoft/yii2-gii `<2.0.4`
- yiisoft/yii2-jui `<2.0.4`

Announcement: http://www.yiiframework.com/news/86/yii-2-0-4-is-released/
The fixing commit: https://github.com/yiisoft/yii2/commit/78d3a856d3b2691a6071d23acd0f75cafe3808e0