### PR TITLE
Add the advisory for the pusher-php-server vulnerability

### DIFF
--- a/pusher/pusher-php-server/2015-05-13.yaml
+++ b/pusher/pusher-php-server/2015-05-13.yaml
@@ -1,0 +1,8 @@
+title:     Exploit in the private channel authentication
+link:      https://blog.pusher.com/update-on-security/
+cve:       ~
+branches:
+    master:
+        time:     2015-05-13 10:53:19
+        versions: [<2.2.1]
+reference: composer://pusher/pusher-php-server


### PR DESCRIPTION
The announcement was not done on a public URL but by sending a mail to their customers actually.
I used the URL of the gist describing the way to apply the same validation for people writing their own implementations.
@leggetter @WillSewell is there a better URL to be used in the advisory ?