### PR TITLE
[Symfony] add affected 2.7 versions for CVE-2015-4050

### DIFF
--- a/symfony/http-kernel/CVE-2015-4050.yaml
+++ b/symfony/http-kernel/CVE-2015-4050.yaml
@@ -14,4 +14,7 @@ branches:
     2.6.x:
         time:     2015-05-26 23:55:51
         versions: [>=2.6.0,<2.6.8]
+    2.7.x:
+        time:     2015-05-26 23:55:51
+        versions: [>=2.7.0-dev,<2.7.0]
 reference: composer://symfony/http-kernel

--- a/symfony/symfony/CVE-2015-4050.yaml
+++ b/symfony/symfony/CVE-2015-4050.yaml
@@ -14,4 +14,7 @@ branches:
     2.6.x:
         time:     2015-05-26 23:55:51
         versions: [>=2.6.0,<2.6.8]
+    2.7.x:
+        time:     2015-05-26 23:55:51
+        versions: [>=2.7.0-dev,<2.7.0]
 reference: composer://symfony/symfony


### PR DESCRIPTION
Thanks to @GrahamCampbell for noticing this.