### PR TITLE
Added laravel socialite vulnerabilities

### DIFF
--- a/laravel/socialite/2015-07-23.yaml
+++ b/laravel/socialite/2015-07-23.yaml
@@ -1,0 +1,11 @@
+title:     Insecure state generation
+link:      https://github.com/laravel/socialite/pull/91
+cve:       ~
+branches:
+    1.0.x:
+        time:     2015-07-23 13:53:00
+        versions: [>=1.0.0,<1.0.99]
+    2.0.x:
+        time:     2015-07-23 13:53:00
+        versions: [>=2.0.0,<2.0.9]
+reference: composer://laravel/socialite

--- a/laravel/socialite/2015-08-03.yaml
+++ b/laravel/socialite/2015-08-03.yaml
@@ -1,0 +1,11 @@
+title:     State guessing vulnerability
+link:      https://github.com/laravel/socialite/pull/93
+cve:       ~
+branches:
+    1.0.x:
+        time:     2015-08-03 12:55:00
+        versions: [>=1.0.0,<1.0.99]
+    2.0.x:
+        time:     2015-08-03 12:55:00
+        versions: [>=2.0.0,<2.0.10]
+reference: composer://laravel/socialite


### PR DESCRIPTION
The first vulnerability was in the fact that the generated state wasn't actually random and the user could work it out from their session.

The second vulnerability prevents two things. The first part of this fix prevents guessing the state through multiple attempts, and the second prevents an attacker from gaining access by not sending a session cookie and then sending no state as a query parameter - in this condition, you could bypass state checking all together because the check to check the state wasn't empty was missing so emtpy === empty was passing...