### PR TITLE
Add the TYPO3 CMS security advisories for 6.2 and 7.x

### DIFF
--- a/typo3/cms/2014-05-22-1.yaml
+++ b/typo3/cms/2014-05-22-1.yaml
@@ -1,0 +1,7 @@
+title:     The ExtJS JavaScript framework that is shipped with TYPO3 is susceptible to XSS
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2014-001/
+branches:
+    6.2.x:
+        time:     2014-05-22 07:34:03
+        versions: [>=6.2.0,<6.2.3]
+reference: composer://typo3/cms

--- a/typo3/cms/2014-10-22-1.yaml
+++ b/typo3/cms/2014-10-22-1.yaml
@@ -1,0 +1,7 @@
+title:     Denial of Service in OpenID System Extension
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2014-002/
+branches:
+    6.2.x:
+        time:     2014-10-22 09:14:28
+        versions: [>=6.2.0,<6.2.6]
+reference: composer://typo3/cms

--- a/typo3/cms/2014-10-22-2.yaml
+++ b/typo3/cms/2014-10-22-2.yaml
@@ -1,0 +1,7 @@
+title:     Arbitrary Shell Execution in Swiftmailer library
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2014-002/
+branches:
+    6.2.x:
+        time:     2014-10-22 09:14:25
+        versions: [>=6.2.0,<6.2.6]
+reference: composer://typo3/cms

--- a/typo3/cms/2014-12-09-1.yaml
+++ b/typo3/cms/2014-12-09-1.yaml
@@ -1,0 +1,10 @@
+title:     Possible link spoofing on the homepage when anchors are used
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2014-003/
+branches:
+    6.2.x:
+        time:     2014-12-10 10:07:58
+        versions: [>=6.2.0,<6.2.9]
+    7.0.x:
+        time:     2014-12-10 10:08:02
+        versions: [>=7.0.0,<7.0.2]
+reference: composer://typo3/cms

--- a/typo3/cms/2014-12-09-2.yaml
+++ b/typo3/cms/2014-12-09-2.yaml
@@ -1,0 +1,10 @@
+title:     Possible cache poisining on the homepage when anchors are used
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2014-003/
+branches:
+    6.2.x:
+        time:     2014-12-10 10:07:58
+        versions: [>=6.2.0,<6.2.9]
+    7.0.x:
+        time:     2014-12-10 10:08:02
+        versions: [>=7.0.0,<7.0.2]
+reference: composer://typo3/cms

--- a/typo3/cms/2015-07-01-1.yaml
+++ b/typo3/cms/2015-07-01-1.yaml
@@ -1,0 +1,19 @@
+title:     Access bypass when editing file metadata
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2015-002/
+branches:
+    6.2.x:
+        time:     2015-07-01 09:10:45
+        versions: [>=6.2.0,<6.2.14]
+    7.0.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.0.0,<7.1.0]
+    7.1.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.1.0,<7.2.0]
+    7.2.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.2.0,<7.3.0]
+    7.3.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.3.0,<7.3.1]
+reference: composer://typo3/cms

--- a/typo3/cms/2015-07-01-2.yaml
+++ b/typo3/cms/2015-07-01-2.yaml
@@ -1,0 +1,19 @@
+title:     Frontend login Session Fixation
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2015-003/
+branches:
+    6.2.x:
+        time:     2015-07-01 14:20:00
+        versions: [>=6.2.0,<6.2.14]
+    7.0.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.0.0,<7.1.0]
+    7.1.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.1.0,<7.2.0]
+    7.2.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.2.0,<7.3.0]
+    7.3.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.3.0,<7.3.1]
+reference: composer://typo3/cms

--- a/typo3/cms/2015-07-01-3.yaml
+++ b/typo3/cms/2015-07-01-3.yaml
@@ -1,0 +1,19 @@
+title:     Cross-Site Scripting exploitable by Editors
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2015-004/
+branches:
+    6.2.x:
+        time:     2015-07-01 14:20:00
+        versions: [>=6.2.0,<6.2.14]
+    7.0.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.0.0,<7.1.0]
+    7.1.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.1.0,<7.2.0]
+    7.2.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.2.0,<7.3.0]
+    7.3.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.3.0,<7.3.1]
+reference: composer://typo3/cms

--- a/typo3/cms/2015-07-01-4.yaml
+++ b/typo3/cms/2015-07-01-4.yaml
@@ -1,0 +1,19 @@
+title:     Information Disclosure possibility exploitable by Editors
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2015-005/
+branches:
+    6.2.x:
+        time:     2015-07-01 14:20:00
+        versions: [>=6.2.0,<6.2.14]
+    7.0.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.0.0,<7.1.0]
+    7.1.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.1.0,<7.2.0]
+    7.2.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.2.0,<7.3.0]
+    7.3.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.3.0,<7.3.1]
+reference: composer://typo3/cms

--- a/typo3/cms/2015-07-01-5.yaml
+++ b/typo3/cms/2015-07-01-5.yaml
@@ -1,0 +1,19 @@
+title:     Brute Force Protection Bypass in backend login
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2015-006/
+branches:
+    6.2.x:
+        time:     2015-07-01 14:20:00
+        versions: [>=6.2.0,<6.2.14]
+    7.0.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.0.0,<7.1.0]
+    7.1.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.1.0,<7.2.0]
+    7.2.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.2.0,<7.3.0]
+    7.3.x:
+        time:     2015-07-01 14:16:00
+        versions: [>=7.3.0,<7.3.1]
+reference: composer://typo3/cms

--- a/typo3/cms/2015-07-01-6.yaml
+++ b/typo3/cms/2015-07-01-6.yaml
@@ -1,0 +1,19 @@
+title:     Cross-Site Scripting in 3rd party library Flowplayer
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2015-007/
+branches:
+    6.2.x:
+        time:     2015-07-01 14:23:00
+        versions: [>=6.2.0,<6.2.14]
+    7.0.x:
+        time:     2015-07-01 14:20:00
+        versions: [>=7.0.0,<7.1.0]
+    7.1.x:
+        time:     2015-07-01 14:20:00
+        versions: [>=7.1.0,<7.2.0]
+    7.2.x:
+        time:     2015-07-01 14:20:00
+        versions: [>=7.2.0,<7.3.0]
+    7.3.x:
+        time:     2015-07-01 14:20:00
+        versions: [>=7.3.0,<7.3.1]
+reference: composer://typo3/cms

--- a/typo3/cms/CVE-2014-3941.yaml
+++ b/typo3/cms/CVE-2014-3941.yaml
@@ -1,0 +1,8 @@
+title:     Possible Host Spoofing through SERVER_NAME
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2014-001/
+cve:       CVE-2014-3941
+branches:
+    6.2.x:
+        time:     2014-05-22 09:34:08
+        versions: [>=6.2.0,<6.2.3]
+reference: composer://typo3/cms

--- a/typo3/cms/CVE-2014-3943.yaml
+++ b/typo3/cms/CVE-2014-3943.yaml
@@ -1,0 +1,8 @@
+title:     Failing to properly encode user input, several backend components are susceptible to XSS
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2014-001/
+cve:       CVE-2014-3943
+branches:
+    6.2.x:
+        time:     2014-05-22 09:34:03
+        versions: [>=6.2.0,<6.2.3]
+reference: composer://typo3/cms

--- a/typo3/cms/CVE-2014-3944.yaml
+++ b/typo3/cms/CVE-2014-3944.yaml
@@ -1,0 +1,8 @@
+title:     Improper Session Invalidation
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2014-001/
+cve:       CVE-2014-3944
+branches:
+    6.2.x:
+        time:     2014-05-22 09:33:36
+        versions: [>=6.2.0,<6.2.3]
+reference: composer://typo3/cms

--- a/typo3/cms/CVE-2014-3946.yaml
+++ b/typo3/cms/CVE-2014-3946.yaml
@@ -1,0 +1,8 @@
+title:     Information disclosure in the Extbase framework
+link:      https://typo3.org/teams/security/security-bulletins/typo3-core/typo3-core-sa-2014-001/
+cve:       CVE-2014-3946
+branches:
+    6.2.x:
+        time:     2014-05-22 09:33:36
+        versions: [>=6.2.0,<6.2.3]
+reference: composer://typo3/cms


### PR DESCRIPTION
Add all the TYPO3 CMS security advisories for 6.2 LTS and 7.x sprint releases, which are available via composer.