### PR TITLE
Switch to the docker-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: php
 
+sudo: false
+
+cache:
+    - $HOME/.composer/cache/files
+
 install:
-    - travis_retry composer install --no-interaction --prefer-source
+    - travis_retry composer install
 
 script:
     - php validator.php


### PR DESCRIPTION
The new infrastructure has a faster boot time, and more capacity, so it is better to use it.