### PR TITLE
Fix lower bounds for an advisory

### DIFF
--- a/namshi/jose/2015-02-19.yaml
+++ b/namshi/jose/2015-02-19.yaml
@@ -7,11 +7,11 @@ branches:
         versions: [<1.1.2]
     "1.2":
         time:     2015-02-19 10:59:35
-        versions: [<1.2.2]
+        versions: [>=1.2.0,<1.2.2]
     "2.0":
         time:     2015-02-19 10:59:35
-        versions: [<2.0.3]
+        versions: [>=2.0.0,<2.0.3]
     "2.1":
         time:     2015-02-19 10:59:35
-        versions: [<2.1.2]
+        versions: [>=2.1.0,<2.1.2]
 reference: composer://namshi/jose


### PR DESCRIPTION
This issue was fixed in each branch, so we need lower bounds on newer branches. Other 1.1.2 will still be considered as impacted.