### PR TITLE
Fixing date for SS-2015-013

### DIFF
--- a/silverstripe/framework/SS-2015-013-1.yaml
+++ b/silverstripe/framework/SS-2015-013-1.yaml
@@ -3,6 +3,6 @@ link:      http://www.silverstripe.org/software/download/security-releases/ss-20
 cve:       ~
 branches:
     3.1.x:
-        time:     2015-05-25 15:12:00
+        time:     2015-05-29 12:53:14 +1200
         versions: [>=3.1.0,<3.1.13]
 reference: composer://silverstripe/framework


### PR DESCRIPTION
I realized that the given date wasn't correct. So I adjusted it to the time of the merge into master:

Date:   Fri May 29 12:53:14 2015 +1200

    Merge pull request #4239 from oddnoc/nginx-x-forwarded-host-docs
    
    Add defense against SS-2015-013 to nginx example
--
commit 9efc384582b6397f52f6d8e637550c21f8b5be78
Author: Fred Condo <fcondo@quinn.com>
Date:   Thu May 28 17:00:33 2015 -0700

    Add defense against SS-2015-013 to nginx example
