### PR TITLE
Add the advisory for DoctrineBundle

### DIFF
--- a/doctrine/doctrine-bundle/2015-08-31.yaml
+++ b/doctrine/doctrine-bundle/2015-08-31.yaml
@@ -1,0 +1,8 @@
+title:     Security Misconfiguration Vulnerability in various Doctrine projects
+link:      http://www.doctrine-project.org/2015/08/31/security_misconfiguration_vulnerability_in_various_doctrine_projects.html
+cve:       CVE-2015-5723
+branches:
+    master:
+        time:     2015-08-31 14:47:06
+        versions: [<1.5.2]
+reference: composer://doctrine/doctrine-bundle


### PR DESCRIPTION
This advisory was forgotten when creating the advisories for the different Doctrine releases for CVE-2015-5723.