### PR TITLE
Validate Composer packages

### DIFF
--- a/silverstripe/cms/SS-2015-008-1.yaml
+++ b/silverstripe/cms/SS-2015-008-1.yaml
@@ -8,4 +8,4 @@ branches:
     3.1.x:
         time:     2015-03-19 16:54:00
         versions: [>=3.1.0,<3.1.11]
-reference: composer://framework/cms
+reference: composer://silverstripe/cms

--- a/validator.php
+++ b/validator.php
@@ -72,6 +72,12 @@ foreach ($dir as $file) {
                 if (str_replace(DIRECTORY_SEPARATOR, '/', dirname($path)) !== $composerPackage) {
                     $messages[$path][] = 'Reference composer package must match the folder name';
                 }
+
+                $packagistUrl = sprintf('https://packagist.org/packages/%s.json', $composerPackage);
+
+                if(404 == explode(' ', get_headers($packagistUrl)[0], 3)[1]) {
+                    $messages[$path][] = sprintf('Invalid composer package');
+                }
             }
         }
 


### PR DESCRIPTION
Although I don't use it, I've spotted that a package seems to have an incorrect Composer name, so I've added a (rather naive) check and corrected it (@spekulatius, could you confirm you meant `silverstripe/cms`?).

This assumes that all Composer packages in this database appear on Packagist (which is currently true, but they don't have to - though would they appear in this database if not?).

I've also noticed that all the SilverStripe advisory URLs are 404s (did they ever work?). Should they be checked too?