### PR TITLE
Update Neos/Flow advisories

### DIFF
--- a/typo3/flow/2012-03-28.yaml
+++ b/typo3/flow/2012-03-28.yaml
@@ -1,5 +1,5 @@
 title:     Insecure Unserialize Vulnerability in FLOW3
-link:      http://typo3.org/teams/security/security-bulletins/typo3-flow/flow3-sa-2012-001/
+link:      https://www.neos.io/news/flow-sa-2012-001.html
 cve:       ~
 branches:
     1.0.x:

--- a/typo3/flow/CVE-2013-7082.yaml
+++ b/typo3/flow/CVE-2013-7082.yaml
@@ -1,5 +1,5 @@
 title:     Cross-Site Scripting in TYPO3 Flow
-link:      http://typo3.org/teams/security/security-bulletins/typo3-flow/typo3-flow-sa-2013-001/
+link:      https://www.neos.io/news/flow-sa-2013-001.html
 cve:       CVE-2013-7082
 branches:
     1.1.x:

--- a/typo3/neos/2015-03-28.yaml
+++ b/typo3/neos/2015-03-28.yaml
@@ -1,5 +1,5 @@
 title:     Privilege Escalation in TYPO3 Neos
-link:      http://typo3.org/teams/security/security-bulletins/typo3-neos/typo3-neos-sa-2015-001/
+link:      https://www.neos.io/news/neos-sa-2015-001.html
 cve:       ~
 branches:
     1.1.x:


### PR DESCRIPTION
Since the projects separated earlier this year, the links to the
bulletins are updated to point to the current (and working) ones.