### PR TITLE
remove invalid version of symfony/security-http

### DIFF
--- a/symfony/security-http/CVE-2015-8124.yaml
+++ b/symfony/security-http/CVE-2015-8124.yaml
@@ -2,9 +2,6 @@ title:     'CVE-2015-8124: Session Fixation in the "Remember Me" Login Feature'
 link:      http://symfony.com/blog/cve-2015-8124-session-fixation-in-the-remember-me-login-feature
 cve:       CVE-2015-8124
 branches:
-    2.3.x:
-        time:     2015-11-23 11:45:06
-        versions: [>=2.3.0,<2.3.35]
     2.6.x:
         time:     2015-11-23 12:41:36
         versions: [>=2.6.0,<2.6.12]


### PR DESCRIPTION
The split of the Symfony Security component was done with the release of
Symfony 2.4.