### PR TITLE
#132 - Improving validator to display violations in constraint strings

### DIFF
--- a/validator.php
+++ b/validator.php
@@ -33,6 +33,11 @@ $advisoryFilter = function (SplFileInfo $file) {
     return true; // any other file gets checks and any other folder gets iterated
 };
 
+$isAcceptableVersionConstraint = function ($versionString) {
+    return (bool) preg_match('/^(\\<|\\>)(=){0,1}(\d+)(\.\d+)*$/', $versionString);
+};
+
+/* @var $dir \SplFileInfo[] */
 $dir = new \RecursiveIteratorIterator(new RecursiveCallbackFilterIterator(new \RecursiveDirectoryIterator(__DIR__), $advisoryFilter));
 foreach ($dir as $file) {
     if (!$file->isFile()) {
@@ -115,6 +120,10 @@ foreach ($dir as $file) {
                 $upperBound = null;
                 $hasMin = false;
                 foreach ($branch['versions'] as $version) {
+                    if (! $isAcceptableVersionConstraint($version)) {
+                        $messages[$path][] = sprintf('Version constraint "%s" is not in an acceptable format.', $version);
+                    }
+
                     if ('<' === substr($version, 0, 1)) {
                         $upperBound = $version;
                         continue;

--- a/validator.php
+++ b/validator.php
@@ -34,7 +34,7 @@ $advisoryFilter = function (SplFileInfo $file) {
 };
 
 $isAcceptableVersionConstraint = function ($versionString) {
-    return (bool) preg_match('/^(\\<|\\>)(=){0,1}(([1-9]\d*)|0)(\.([1-9]\d*)|0)*(-(alpha|beta|rc)[1-9]\d*){0,1}$/', $versionString);
+    return (bool) preg_match('/^(\\<|\\>)(=){0,1}(([1-9]\d*)|0)(\.(([1-9]\d*)|0))*(-(alpha|beta|rc)[1-9]\d*){0,1}$/', $versionString);
 };
 
 /* @var $dir \SplFileInfo[] */

--- a/validator.php
+++ b/validator.php
@@ -34,7 +34,7 @@ $advisoryFilter = function (SplFileInfo $file) {
 };
 
 $isAcceptableVersionConstraint = function ($versionString) {
-    return (bool) preg_match('/^(\\<|\\>)(=){0,1}([1-9]\d*)(\.[1-9]\d*)*(-(alpha|beta|rc)[1-9]\d*){0,1}$/', $versionString);
+    return (bool) preg_match('/^(\\<|\\>)(=){0,1}(([1-9]\d*)|0)(\.([1-9]\d*)|0)*(-(alpha|beta|rc)[1-9]\d*){0,1}$/', $versionString);
 };
 
 /* @var $dir \SplFileInfo[] */

--- a/validator.php
+++ b/validator.php
@@ -34,7 +34,7 @@ $advisoryFilter = function (SplFileInfo $file) {
 };
 
 $isAcceptableVersionConstraint = function ($versionString) {
-    return (bool) preg_match('/^(\\<|\\>)(=){0,1}(\d+)(\.\d+)*(-(alpha|beta|rc)\d+){0,1}$/', $versionString);
+    return (bool) preg_match('/^(\\<|\\>)(=){0,1}([1-9]\d*)(\.[1-9]\d*)*(-(alpha|beta|rc)[1-9]\d*){0,1}$/', $versionString);
 };
 
 /* @var $dir \SplFileInfo[] */

--- a/validator.php
+++ b/validator.php
@@ -34,7 +34,7 @@ $advisoryFilter = function (SplFileInfo $file) {
 };
 
 $isAcceptableVersionConstraint = function ($versionString) {
-    return (bool) preg_match('/^(\\<|\\>)(=){0,1}(\d+)(\.\d+)*$/', $versionString);
+    return (bool) preg_match('/^(\\<|\\>)(=){0,1}(\d+)(\.\d+)*(-(alpha|beta|rc)\d+){0,1}$/', $versionString);
 };
 
 /* @var $dir \SplFileInfo[] */


### PR DESCRIPTION
This test adds validation required for the changes in #132

Note: this restricts version constraints accepted in this repository.
Note: will fail on the PR branch (on purpose) with an output like following:

```
codeigniter/framework/2015-10-31-1.yaml
    Version constraint "<3.0.3'" is not acceptable.
doctrine/doctrine-bundle/2015-08-31.yaml
    Version constraint "<1.5.2'" is not acceptable.
thelia/thelia/2015-04-13-1.yaml
    Version constraint ">=2.1.0-beta1" is not acceptable.
zendframework/zendframework1/ZF2010-03.yaml
    Version constraint "<1.8.5'" is not acceptable.
```

Once merged into `master`, it shouldn't report any failures.