### PR TITLE
Add CVE-2016-3124 (simplesamlphp/simplesamlphp).

### DIFF
--- a/simplesamlphp/simplesamlphp/CVE-2016-3124.yaml
+++ b/simplesamlphp/simplesamlphp/CVE-2016-3124.yaml
@@ -5,7 +5,4 @@ branches:
     master:
         time:       2016-03-07 13:04:57
         versions:   ['<=1.14.1']
-    1.14:
-        time:       2016-03-07 13:06:15
-        versions:   ['<=1.14.1']
 reference:  composer://simplesamlphp/simplesamlphp

--- a/simplesamlphp/simplesamlphp/CVE-2016-3124.yaml
+++ b/simplesamlphp/simplesamlphp/CVE-2016-3124.yaml
@@ -1,0 +1,11 @@
+title:      Information leakage issue in the sanitycheck module
+link:       https://simplesamlphp.org/security/201603-01
+cve:        CVE-2016-3124
+branches:
+    master:
+        time:       2016-03-07 13:04:57
+        versions:   ['<=1.14.1']
+    1.14:
+        time:       2016-03-07 13:06:15
+        versions:   ['<=1.14.1']
+reference:  composer://simplesamlphp/simplesamlphp


### PR DESCRIPTION
This PR adds information for [CVE-2016-3124](https://simplesamlphp.org/security/201603-01) (assigned but pending upload to the CVE database), an information disclosure security issue in `simplesamlphp/simplesamlphp`.