### PR TITLE
paragonie/random_compat 1.* uses insecure CSPRNG (openssl_random_pseudo_bytes())

### DIFF
--- a/paragonie/random_compat/2016-03-16.yaml
+++ b/paragonie/random_compat/2016-03-16.yaml
@@ -4,5 +4,5 @@ cve:       ~
 branches:
     1.x:
         time:     ~
-        versions: ['^1.0']
+        versions: ['<2.0']
 reference: composer://paragonie/random_compat

--- a/paragonie/random_compat/2016-03-16.yaml
+++ b/paragonie/random_compat/2016-03-16.yaml
@@ -1,0 +1,8 @@
+title:     Uses insecure CSPRNG (openssl_random_pseudo_bytes())
+link:      https://github.com/paragonie/random_compat/issues/96
+cve:       ~
+branches:
+    1.x:
+        time:     ~
+        versions: ['^1.0']
+reference: composer://paragonie/random_compat

--- a/paragonie/random_compat/2016-03-16.yaml
+++ b/paragonie/random_compat/2016-03-16.yaml
@@ -3,6 +3,6 @@ link:      https://github.com/paragonie/random_compat/issues/96
 cve:       ~
 branches:
     1.x:
-        time:     ~
+        time:     2016-03-16 00:00:00
         versions: ['<2.0']
 reference: composer://paragonie/random_compat


### PR DESCRIPTION
https://github.com/paragonie/random_compat/issues/96

TL;DR - In environments where the PHP process is forked, `openssl_random_psuedo_bytes` can generate the same stream of values.

There are other security issues that also caused @paragonie-scott concern. 

Also I'm not sure what to do with the branch name, the vulnerability spans more than one branch and can best be described as "all versions 1.*? (edit - as @stof mentioned it's actually all versions <2 )
