### PR TITLE
adds simplesamlphp/simplesamlphp 201606-01: Link injection

### DIFF
--- a/simplesamlphp/simplesamlphp/201606-01.yaml
+++ b/simplesamlphp/simplesamlphp/201606-01.yaml
@@ -1,0 +1,7 @@
+title:     Link injection
+link:      https://simplesamlphp.org/security/201606-01
+branches:
+    master:
+        time:     2016-06-06 10:50:00
+        versions: ['<1.14.4']
+reference: composer://simplesamlphp/simplesamlphp


### PR DESCRIPTION
I'm not really sure about the naming of the file.

For the zendframework issues the name given by the advisory naming (e.g. https://github.com/FriendsOfPHP/security-advisories/blob/master/zendframework/zendframework1/ZF2016-02.yaml), so in this case it should be `201606-01` for the simplesamlphp issue. Following the contribute guide it should be `2016-06-08-1`. In case of doctrine only the date of announcement without an increment is used. Any hints?!