### PR TITLE
Added bugsnag laravel vulnerability

### DIFF
--- a/bugsnag/bugsnag-laravel/CVE-2016-5385.yaml
+++ b/bugsnag/bugsnag-laravel/CVE-2016-5385.yaml
@@ -1,0 +1,8 @@
+title:     HTTP Proxy header vulnerability
+link:      https://github.com/bugsnag/bugsnag-laravel/releases/tag/v2.0.2
+cve:       CVE-2016-5385
+branches:
+    master:
+        time:     2016-07-18 20:27:36
+        versions: ['>=2', '<2.0.2']
+reference: composer://bugsnag/bugsnag-laravel


### PR DESCRIPTION
1.x of the package was not affected because it did not use guzzle.