### PR TITLE
Add CVE-2016-5385 for Artax

### DIFF
--- a/amphp/artax/CVE-2016-5385.yaml
+++ b/amphp/artax/CVE-2016-5385.yaml
@@ -1,0 +1,11 @@
+title:     HTTP Proxy header vulnerability
+link:      https://twitter.com/asyncphp/status/755136084917583872
+cve:       CVE-2016-5385
+branches:
+    master:
+        time:     2016-07-18 16:37:40
+        versions: ['>=2', '<2.0.4']
+    1.0.x:
+        time:     2016-07-18 16:37:40
+        versions: ['>=1', '<1.0.4']
+reference: composer://amphp/artax

--- a/amphp/artax/CVE-2016-5385.yaml
+++ b/amphp/artax/CVE-2016-5385.yaml
@@ -5,7 +5,7 @@ branches:
     master:
         time:     2016-07-18 16:37:40
         versions: ['>=2', '<2.0.4']
-    1.0.x:
+    1.x:
         time:     2016-07-18 16:37:40
         versions: ['>=1', '<1.0.4']
 reference: composer://amphp/artax

--- a/amphp/artax/CVE-2016-5385.yaml
+++ b/amphp/artax/CVE-2016-5385.yaml
@@ -7,5 +7,5 @@ branches:
         versions: ['>=2', '<2.0.4']
     1.x:
         time:     2016-07-18 16:37:40
-        versions: ['>=1', '<1.0.4']
+        versions: ['>0.7.1', '<1.0.4']
 reference: composer://amphp/artax


### PR DESCRIPTION
Code has been introduced in https://github.com/amphp/artax/commit/6f8b6c2b#diff-da1906ee835fb5c0e62dc9db19aff36fR27.

`git tag --contains 6f8b6c2b` lists the following tags to ~~be affected~~ contain the above commit:

```
v1.0.0
v1.0.0-alpha
v1.0.0-beta
v1.0.0-beta2
v1.0.0-rc1
v1.0.0-rc2
v1.0.0-rc3
v1.0.0-rc4
v1.0.0-rc5
v1.0.0-rc6
v1.0.1
v1.0.2
v1.0.3
v1.0.4
v2.0.0
v2.0.1
v2.0.2
v2.0.3
v2.0.4
```

I guess `>=1` doesn't cover `v1.0.0-alpha`? What would be the right constraint here?