### PR TITLE
duplicating drupal/drupal advisories to drupal/core

### DIFF
--- a/drupal/core/CVE-2016-3162.yaml
+++ b/drupal/core/CVE-2016-3162.yaml
@@ -1,0 +1,8 @@
+title:     File upload access bypass and denial of service
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3162
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-3163.yaml
+++ b/drupal/core/CVE-2016-3163.yaml
@@ -1,0 +1,8 @@
+title:     Brute force amplification attacks via XML-RPC
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3163
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-3164.yaml
+++ b/drupal/core/CVE-2016-3164.yaml
@@ -1,0 +1,8 @@
+title:     Open redirect via path manipulation
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3164
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-3165.yaml
+++ b/drupal/core/CVE-2016-3165.yaml
@@ -1,0 +1,8 @@
+title:     Form API ignores access restrictions on submit buttons
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3165
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-3166.yaml
+++ b/drupal/core/CVE-2016-3166.yaml
@@ -1,0 +1,8 @@
+title:     HTTP header injection using line breaks
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3166
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-3167.yaml
+++ b/drupal/core/CVE-2016-3167.yaml
@@ -1,0 +1,8 @@
+title:     Open redirect via double-encoded 'destination' parameter
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3167
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-3168.yaml
+++ b/drupal/core/CVE-2016-3168.yaml
@@ -1,0 +1,8 @@
+title:     Reflected file download vulnerability
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3168
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-3169.yaml
+++ b/drupal/core/CVE-2016-3169.yaml
@@ -1,0 +1,8 @@
+title:     Saving user accounts can sometimes grant the user all roles
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3169
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-3170.yaml
+++ b/drupal/core/CVE-2016-3170.yaml
@@ -1,0 +1,8 @@
+title:     Email address can be matched to an account
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3170
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-3171.yaml
+++ b/drupal/core/CVE-2016-3171.yaml
@@ -1,0 +1,8 @@
+title:     Session data truncation can lead to unserialization of user provided data
+link:      https://www.drupal.org/SA-CORE-2016-001
+cve:       CVE-2016-3171
+branches:
+    8.0.x:
+        time:     2016-02-15 18:57:00
+        versions: ['>=8.0','<8.0.4']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-5385.yaml
+++ b/drupal/core/CVE-2016-5385.yaml
@@ -1,0 +1,11 @@
+title:     Drupal Core - Highly Critical - Injection - SA-CORE-2016-003
+link:      https://www.drupal.org/SA-CORE-2016-003
+cve:       CVE-2016-5385
+branches:
+    8.0.x:
+        time:     2016-07-18 16:01:00
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2016-07-18 16:01:00
+        versions: ['>=8.1.0','<8.1.7']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-6211.yaml
+++ b/drupal/core/CVE-2016-6211.yaml
@@ -1,0 +1,11 @@
+title:     Saving user accounts can sometimes grant the user all roles
+link:      https://www.drupal.org/SA-CORE-2016-002
+cve:       CVE-2016-6211
+branches:
+    8.0.x:
+        time:     2016-06-15 20:59:00
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2016-06-15 20:59:00
+        versions: ['>=8.1.0','<8.1.3']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2016-6212.yaml
+++ b/drupal/core/CVE-2016-6212.yaml
@@ -1,0 +1,11 @@
+title:     Views can allow unauthorized users to see Statistics information
+link:      https://www.drupal.org/SA-CORE-2016-002
+cve:       CVE-2016-6212
+branches:
+    8.0.x:
+        time:     2016-06-15 20:59:00
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2016-06-15 20:59:00
+        versions: ['>=8.1.0','<8.1.3']
+reference: composer://drupal/core


### PR DESCRIPTION
Following the contribution guide "If some affected code is available through different Composer entries (like when you have read-only subtree splits of a main repository), duplicate the information in several files." I just duplicated the advisories. Should fix #163.