### PR TITLE
Add Gregwar/RST < v1.0.3

### DIFF
--- a/gregwar/rst/2016-10-31.yaml
+++ b/gregwar/rst/2016-10-31.yaml
@@ -3,5 +3,6 @@ link:      https://hackerone.com/reports/179034
 cve:       ~
 branches:
     master:
+        time: 2016-10-31 09:00:00
         versions: ['<1.0.3']
 reference: composer://gregwar/rst

--- a/gregwar/rst/2016-10-31.yaml
+++ b/gregwar/rst/2016-10-31.yaml
@@ -1,0 +1,7 @@
+title:     Local File Inclusion Vulnerability
+link:      https://hackerone.com/reports/179034
+cve:       ~
+branches:
+    master:
+        versions: ['<1.0.3']
+reference: composer://gregwar/rst


### PR DESCRIPTION
There's a local file inclusion vulnerability in Gregwar/RST < 1.0.3. Even if you're using a newer version, you still have to go through [some steps](https://twitter.com/CiPHPerCoder/status/793076643468304384) to disable it properly.