### PR TITLE
simplesamlphp SSPSA 201612-01: Incorrect signature validation

### DIFF
--- a/simplesamlphp/simplesamlphp/201612-01.yaml
+++ b/simplesamlphp/simplesamlphp/201612-01.yaml
@@ -1,0 +1,7 @@
+title:     Incorrect signature verification
+link:      https://simplesamlphp.org/security/201612-01
+branches:
+    master:
+        time:     2016-12-02 16:23:00
+        versions: ['<1.14.10']
+reference: composer://simplesamlphp/simplesamlphp


### PR DESCRIPTION
This has already beed added for `simplesamlphp/saml2` in #182 but SimpleSAMLphp itself is also affected.