### PR TITLE
simplesamlphp SSPSA 201612-02: Incorrect signature validation

### DIFF
--- a/simplesamlphp/simplesamlphp/201612-02.yaml
+++ b/simplesamlphp/simplesamlphp/201612-02.yaml
@@ -1,0 +1,7 @@
+title:     Incorrect signature verification
+link:      https://simplesamlphp.org/security/201612-02
+branches:
+    1.14.x:
+        time:     2016-12-03 13:14:00
+        versions: ['<1.14.11']
+reference: composer://simplesamlphp/simplesamlphp


### PR DESCRIPTION
This time I'm rather sure that the issue is in simplesamlphp directly and not in a dependency.
The commit with the fix should be: https://github.com/simplesamlphp/simplesamlphp/commit/a2326d75dd14accaac162dd2cb30aaefcc1f9205

Maybe @marcomenzel could verify this before merging?