### PR TITLE
fix typo3/cms branches/version for two advisories

### DIFF
--- a/typo3/cms/2016-11-22-1.yaml
+++ b/typo3/cms/2016-11-22-1.yaml
@@ -18,5 +18,8 @@ branches:
         versions: ['>=8.2.0', '<8.3.0']
     8.3.x:
         time:     2016-11-22 10:09:00
-        versions: ['>=8.3.0', '<8.4.1']
+        versions: ['>=8.3.0', '<8.4.0']
+    8.4.x:
+        time:     2016-11-22 10:09:00
+        versions: ['>=8.4.0', '<8.4.1']
 reference: composer://typo3/cms

--- a/typo3/cms/2016-11-22-2.yaml
+++ b/typo3/cms/2016-11-22-2.yaml
@@ -18,5 +18,8 @@ branches:
         versions: ['>=8.2.0', '<8.3.0']
     8.3.x:
         time:     2016-11-22 10:09:00
-        versions: ['>=8.3.0', '<8.4.1']
+        versions: ['>=8.3.0', '<8.4.0']
+    8.4.x:
+        time:     2016-11-22 10:09:00
+        versions: ['>=8.4.0', '<8.4.1']
 reference: composer://typo3/cms


### PR DESCRIPTION
fixing mistakes made in d01ca7e9299e18eb7ca4c551a4ea491340af3b99
should be self-explanatory :angel: 