### PR TITLE
Updated the Shopware RCE vuln to reflect improved release

### DIFF
--- a/shopware/shopware/2017-01-24.yaml
+++ b/shopware/shopware/2017-01-24.yaml
@@ -15,5 +15,5 @@ branches:
         versions: ['>=5.1.0', '<5.2.0']
     5.2:
         time:     2017-01-19 08:19:00
-        versions: ['>=5.2.0', '<5.2.15']
+        versions: ['>=5.2.0', '<5.2.16']
 reference: composer://shopware/shopware


### PR DESCRIPTION
We released a improved version of the bugfix so we recommend at least SW 5.2.16