### PR TITLE
Add the SUPEE-9652 RCE in Magento 1.x CE/EE

### DIFF
--- a/magento/magento1ce/2017-02-07.yaml
+++ b/magento/magento1ce/2017-02-07.yaml
@@ -1,0 +1,9 @@
+title:     SUPEE-9652 - Remote Code Execution using mail vulnerability
+link:      https://magento.com/security/patches/supee-9652
+cve:       ~
+branches:
+    1.x:
+        time:     2017-02-07 00:00:00
+        versions: ['>=1.5.0.1', '<1.9.3.2']
+reference: composer://magento/magento1ce
+composer-repository: false

--- a/magento/magento1ee/2017-02-07.yaml
+++ b/magento/magento1ee/2017-02-07.yaml
@@ -1,0 +1,9 @@
+title:     SUPEE-9652 - Remote Code Execution using mail vulnerability
+link:      https://magento.com/security/patches/supee-9652
+cve:       ~
+branches:
+    1.x:
+        time:     2017-02-07 00:00:00
+        versions: ['>=1.9.0.0', '<1.14.3.2']
+reference: composer://magento/magento1ee
+composer-repository: false


### PR DESCRIPTION
This vulnerability exists in the underlying Zend 1.x library. The
upstream Zend library has hit EOL, however Magento maintains a fork of
the library with security fixes as they migrate to Zend 2.x (in Magento
2)

This vulnerability exists in code in both the CE and EE version

Fixes #202