### PR TITLE
fixing drupal advisory constraints

### DIFF
--- a/drupal/core/CVE-2016-9449.yaml
+++ b/drupal/core/CVE-2016-9449.yaml
@@ -7,5 +7,8 @@ branches:
         versions: ['>=8.0','<8.1.0']
     8.1.x:
         time:     2016-11-16 18:45:00
-        versions: ['>=8.1.0','<8.2.3']
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2016-11-16 18:45:00
+        versions: ['>=8.2.0','<8.2.3']
 reference: composer://drupal/core

--- a/drupal/core/CVE-2016-9450.yaml
+++ b/drupal/core/CVE-2016-9450.yaml
@@ -7,5 +7,8 @@ branches:
         versions: ['>=8.0','<8.1.0']
     8.1.x:
         time:     2016-11-16 18:45:00
-        versions: ['>=8.1.0','<8.2.3']
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2016-11-16 18:45:00
+        versions: ['>=8.2.0','<8.2.3']
 reference: composer://drupal/core

--- a/drupal/core/CVE-2016-9452.yaml
+++ b/drupal/core/CVE-2016-9452.yaml
@@ -7,5 +7,8 @@ branches:
         versions: ['>=8.0','<8.1.0']
     8.1.x:
         time:     2016-11-16 18:45:00
-        versions: ['>=8.1.0','<8.2.3']
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2016-11-16 18:45:00
+        versions: ['>=8.2.0','<8.2.3']
 reference: composer://drupal/core

--- a/drupal/drupal/CVE-2016-9449.yaml
+++ b/drupal/drupal/CVE-2016-9449.yaml
@@ -7,5 +7,8 @@ branches:
         versions: ['>=8.0','<8.1.0']
     8.1.x:
         time:     2016-11-16 18:45:00
-        versions: ['>=8.1.0','<8.2.3']
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2016-11-16 18:45:00
+        versions: ['>=8.2.0','<8.2.3']
 reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2016-9450.yaml
+++ b/drupal/drupal/CVE-2016-9450.yaml
@@ -7,5 +7,8 @@ branches:
         versions: ['>=8.0','<8.1.0']
     8.1.x:
         time:     2016-11-16 18:45:00
-        versions: ['>=8.1.0','<8.2.3']
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2016-11-16 18:45:00
+        versions: ['>=8.2.0','<8.2.3']
 reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2016-9452.yaml
+++ b/drupal/drupal/CVE-2016-9452.yaml
@@ -7,5 +7,8 @@ branches:
         versions: ['>=8.0','<8.1.0']
     8.1.x:
         time:     2016-11-16 18:45:00
-        versions: ['>=8.1.0','<8.2.3']
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2016-11-16 18:45:00
+        versions: ['>=8.2.0','<8.2.3']
 reference: composer://drupal/drupal


### PR DESCRIPTION
the `branches` used for SA-CORE-2016-005 aren't correct.
This pr will fix them.