### PR TITLE
Fix illuminate/* links

### DIFF
--- a/illuminate/auth/2014-04-15.yaml
+++ b/illuminate/auth/2014-04-15.yaml
@@ -1,5 +1,5 @@
 title:     Hijacked authentication cookies vulnerability
-link:      http://laravel.com/docs/upgrade#upgrade-4.1.26
+link:      https://laravel.com/docs/5.1/upgrade#upgrade-4.1.26
 cve:       ~
 branches:
     4.0.x:

--- a/illuminate/database/2014-05-20.yaml
+++ b/illuminate/database/2014-05-20.yaml
@@ -1,5 +1,5 @@
 title:     Risk of mass-assignment vulnerabilities
-link:      http://laravel.com/docs/upgrade#upgrade-4.1.29
+link:      https://laravel.com/docs/5.1/upgrade#upgrade-4.1.29
 cve:       ~
 branches:
     4.0.x:


### PR DESCRIPTION
- Use https
- Use 5.1 docs because upgrade guides for 4.* were removed in 5.2 docs