### PR TITLE
add onelogin/php-saml security issues

### DIFF
--- a/onelogin/php-saml/2016-10-04.yaml
+++ b/onelogin/php-saml/2016-10-04.yaml
@@ -1,0 +1,8 @@
+title:     Vulnerability to Response Wrapping attacks resulting in a malicious user gaining unauthorized access to a system.
+link:      https://github.com/onelogin/php-saml/commit/9d31baa97a57b0989020f62d24307c29e325dac3
+cve:       CVE-2016-1000253
+branches:
+    "2.x":
+        time:     2016-10-04 15:39:00
+        versions: [<2.10.0]
+reference: composer://onelogin/php-saml

--- a/onelogin/php-saml/2017-02-28.yaml
+++ b/onelogin/php-saml/2017-02-28.yaml
@@ -1,0 +1,8 @@
+title:     An error during signature verification can be treated as a successful verification.
+link:      https://github.com/onelogin/php-saml/commit/949359f5cad5e1d085c4e5447d9aa8f49a6e82a1
+cve:       ~
+branches:
+    "2.x":
+        time:     2017-02-28 15:37:00
+        versions: [<2.10.4]
+reference: composer://onelogin/php-saml


### PR DESCRIPTION
Based on the warnings in the README file of the library, I added these 2 security related matters. I am not sure if the CVE mentioned in the README should be added. I can't find the CVE in the official CVE database.

https://github.com/onelogin/php-saml/blob/master/README.md