### PR TITLE
add simplesamlphp/simplesamlphp SSPSA 201709-01

### DIFF
--- a/simplesamlphp/simplesamlphp/201709-01.yaml
+++ b/simplesamlphp/simplesamlphp/201709-01.yaml
@@ -1,6 +1,12 @@
 title:     Cross Site Scripting (XSS) in the consentAdmin module
 link:      https://simplesamlphp.org/security/201709-01
 branches:
+    1.12.x:
+        time:     2017-08-25 11:35:00
+        versions: ['>=1.12.0', '<1.13.0']
+    1.13.x:
+        time:     2017-08-25 11:35:00
+        versions: ['>=1.13.0', '<1.14.0']
     1.14.x:
         time:     2017-08-25 11:35:00
         versions: ['>=1.14.0', '<1.14.16']


### PR DESCRIPTION
Like @stof mentioned in https://github.com/FriendsOfPHP/security-advisories/pull/225/files#r137498654 I added 1.12.x and 1.13.x which are affected by SSPSA 201709-01 and distributed by composer/packagist.