### PR TITLE
Relax time constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ Contributing security advisories is as easy as it can get:
 
           * `time`: The date when the security issue was fixed (most of the
             time the date of the commit that fixed the issue (`2012-08-27
-            19:17:44`) -- this information must be as accurate as possible as
+            19:17:44`)) -- this information must be as accurate as possible as
             it is used to determined if a software is affected or not;
+            optional if and only if `unfixed` is also specified
 
           * `versions`: An array of constraints describing affected versions
             for this branch (this is the same format as the one used for

--- a/validator.php
+++ b/validator.php
@@ -162,8 +162,11 @@ final class Validate extends Command
                         }
                     }
 
-                    if (!isset($branch['time'])) {
-                        $messages[$path][] = sprintf('Key "time" is required for branch "%s".', $name);
+                    if (!isset($branch['time']) && !isset($branch['unfixed'])) {
+                        $messages[$path][] = sprintf(
+                            'Key "time" is required for branch "%s", unless "unfixed" is specified too.',
+                            $name
+                        );
                     }
 
                     if (!isset($branch['versions'])) {
@@ -188,7 +191,7 @@ final class Validate extends Command
                         }
 
                         if (null === $upperBound) {
-                            $messages[$path][] = sprintf('"versions" must have an upper bound for branch "%s".', $name);
+                            $messages[$path][] = sprintf('"versions" must have an upper bound for branch "%s" unless "unfixed" is also specified.', $name);
                         }
 
                         if (!$hasMin && null === $upperBoundWithoutLowerBound) {


### PR DESCRIPTION
See #241 discussion

If `unfixed` is specified for a branch, this allows `time` to be optional and an upper bound to be omitted.