### PR TITLE
Specify Sentry version

### DIFF
--- a/cartalyst/sentry/2016-09-05.yaml
+++ b/cartalyst/sentry/2016-09-05.yaml
@@ -2,7 +2,7 @@ title:     Null reset codes were allowed
 link:      http://haxx.ml/post/149975211631/how-i-hacked-your-cfp-and-probably-some-other
 cve:       ~
 branches:
-    2.1:
+    2.1.x:
         time:     2016-10-04 20:18:00
-        versions: ['<2.1']
+        versions: ['<=2.1.6']
 reference: composer://cartalyst/sentry


### PR DESCRIPTION
This issue didn't get fixed until 2.1.7

See also [This comment](https://github.com/cartalyst/sentry/pull/545#issuecomment-346587360)