### PR TITLE
Add the advisory for the gree/jose vulnerability

### DIFF
--- a/gree/jose/2016-08-30.yaml
+++ b/gree/jose/2016-08-30.yaml
@@ -1,0 +1,8 @@
+title: Critical vulnerabilities in JSON Web Token libraries
+link: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+cve: ~
+branches:
+  master: 
+    time: 2016-08-30 10:37:36
+    versions: [<=2.2.0]
+reference: composer://gree/jose


### PR DESCRIPTION
The fix against algorithm spoofing has been added to version 2.2.1:
https://github.com/nov/jose-php/blob/master/src/JOSE/JWS.php#L131