### PR TITLE
fixed typo in version of phpxmlrpc.

### DIFF
--- a/phpxmlrpc/extras/2017-10-29.yaml
+++ b/phpxmlrpc/extras/2017-10-29.yaml
@@ -4,5 +4,5 @@ cve:       ~
 branches:
     master:
         time:     2017-10-29 12:24:59
-        versions: [<6.0.1]
+        versions: [<0.6.1]
 reference: composer://phpxmlrpc/extras


### PR DESCRIPTION
it seems that the version was wrong according to https://github.com/gggeek/phpxmlrpc-extras/releases/tag/0.6.1 linked in the file.