### PR TITLE
Add CVE IDs to several advisories

### DIFF
--- a/simplesamlphp/saml2/CVE-2018-6519.yaml
+++ b/simplesamlphp/saml2/CVE-2018-6519.yaml
@@ -1,5 +1,6 @@
 title:     Denial of Service in timestamp validation function
 link:      https://simplesamlphp.org/security/201801-01
+cve:       CVE-2018-6519
 branches:
     1.10.x:
         time:     2018-01-25 10:26:00

--- a/simplesamlphp/simplesamlphp/CVE-2017-18121.yaml
+++ b/simplesamlphp/simplesamlphp/CVE-2017-18121.yaml
@@ -1,5 +1,6 @@
 title:     Cross Site Scripting (XSS) in the consentAdmin module
 link:      https://simplesamlphp.org/security/201709-01
+cve:       CVE-2017-18121
 branches:
     1.12.x:
         time:     2017-08-25 11:35:00

--- a/simplesamlphp/simplesamlphp/CVE-2017-18122.yaml
+++ b/simplesamlphp/simplesamlphp/CVE-2017-18122.yaml
@@ -1,5 +1,6 @@
 title:     Signature validation bypass (SAML 1.1)
 link:      https://simplesamlphp.org/security/201710-01
+cve:       CVE-2018-18122
 branches:
     1.14.x:
         time:     2017-10-25 10:54:00

--- a/simplesamlphp/simplesamlphp/CVE-2018-6520.yaml
+++ b/simplesamlphp/simplesamlphp/CVE-2018-6520.yaml
@@ -1,5 +1,6 @@
 title:     Open redirection protection bypass
 link:      https://simplesamlphp.org/security/201801-02
+cve:       CVE-2018-6520
 branches:
     1.15.x:
         time:     2018-01-31 10:34:00

--- a/simplesamlphp/simplesamlphp/CVE-2018-6521.yaml
+++ b/simplesamlphp/simplesamlphp/CVE-2018-6521.yaml
@@ -1,5 +1,6 @@
 title:     Use of insecure connection charset (sqlauth module)
 link:      https://simplesamlphp.org/security/201801-03
+cve:       CVE-2018-6521
 branches:
     1.15.x:
         time:     2018-01-31 10:34:00


### PR DESCRIPTION
We've got CVE IDs for the 5 advisories missing them in SimpleSAMLphp. Here are they.