### PR TITLE
added Yii Framework CVE-2018-6009 and CVE-2018-6010

### DIFF
--- a/yiisoft/yii2-dev/CVE-2015-5467.yaml
+++ b/yiisoft/yii2-dev/CVE-2015-5467.yaml
@@ -1,0 +1,8 @@
+title:     class yii\web\ViewAction allowed to include arbitrary files that end with .php
+link:      http://www.yiiframework.com/news/87/yii-2-0-5-is-released-security-fix/
+cve:       CVE-2015-5467
+branches:
+    2.0.x:
+        time:     2015-07-10 18:12:53
+        versions: [<2.0.5]
+reference: composer://yiisoft/yii2-dev

--- a/yiisoft/yii2-dev/CVE-2018-6009.yaml
+++ b/yiisoft/yii2-dev/CVE-2018-6009.yaml
@@ -1,0 +1,8 @@
+title:     The switchIdentity() function in yii\web\User did not regenerate the CSRF token upon a change of identity
+link:      http://www.yiiframework.com/news/165/yii-2-0-14-is-released/
+cve:       CVE-2018-6009
+branches:
+    2.0.x:
+        time:     2018-01-13 23:13
+        versions: [<2.0.14]
+reference: composer://yiisoft/yii2-dev

--- a/yiisoft/yii2-dev/CVE-2018-6010.yaml
+++ b/yiisoft/yii2-dev/CVE-2018-6010.yaml
@@ -1,0 +1,8 @@
+title:     Remote attackers could obtain potentially sensitive information from exception messages printed by the error handler in non-debug mode.
+link:      http://www.yiiframework.com/news/165/yii-2-0-14-is-released/
+cve:       CVE-2018-6010
+branches:
+    2.0.x:
+        time:     2018-01-22 08:41
+        versions: [<2.0.14]
+reference: composer://yiisoft/yii2-dev

--- a/yiisoft/yii2/CVE-2018-6009.yaml
+++ b/yiisoft/yii2/CVE-2018-6009.yaml
@@ -1,0 +1,8 @@
+title:     The switchIdentity() function in yii\web\User did not regenerate the CSRF token upon a change of identity
+link:      http://www.yiiframework.com/news/165/yii-2-0-14-is-released/
+cve:       CVE-2018-6009
+branches:
+    2.0.x:
+        time:     2018-01-13 23:13
+        versions: [<2.0.14]
+reference: composer://yiisoft/yii2

--- a/yiisoft/yii2/CVE-2018-6010.yaml
+++ b/yiisoft/yii2/CVE-2018-6010.yaml
@@ -1,0 +1,8 @@
+title:     Remote attackers could obtain potentially sensitive information from exception messages printed by the error handler in non-debug mode.
+link:      http://www.yiiframework.com/news/165/yii-2-0-14-is-released/
+cve:       CVE-2018-6010
+branches:
+    2.0.x:
+        time:     2018-01-22 08:41
+        versions: [<2.0.14]
+reference: composer://yiisoft/yii2


### PR DESCRIPTION
These are fixed with todays release of Yii 2.0.14.

http://www.yiiframework.com/news/165/yii-2-0-14-is-released/

See "Security" headline for details.

Both issues affect packages `yiisoft/yii2` and `yiisoft/yii2-dev` so the files are duplicated for these.

Also copied a missing CVE-2015-5467 from `yiisoft/yii2` to `yiisoft/yii2-dev`.