### PR TITLE
Allow time to be null when the issue is not fixed yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Contributing security advisories is as easy as it can get:
             issue is not fixed yet (most of the time, the date of the commit
             that fixed the issue in the following format `2012-08-27 19:17:44`)
             -- this information must be as accurate as possible as it is used
-            to determined if a software is affected or not;
+            to determine if a project is affected or not;
 
           * `versions`: An array of constraints describing affected versions
             for this branch (this is the same format as the one used for

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ Contributing security advisories is as easy as it can get:
         name (like `2.0.x`), and the value is a hash with the following
         entries:
 
-          * `time`: The date when the security issue was fixed (most of the
-            time the date of the commit that fixed the issue (`2012-08-27
-            19:17:44`) -- this information must be as accurate as possible as
-            it is used to determined if a software is affected or not;
+          * `time`: The date when the security issue was fixed or null if the
+            issue is not fixed yet (most of the time, the date of the commit
+            that fixed the issue in the following format `2012-08-27 19:17:44`)
+            -- this information must be as accurate as possible as it is used
+            to determined if a software is affected or not;
 
           * `versions`: An array of constraints describing affected versions
             for this branch (this is the same format as the one used for

--- a/validator.php
+++ b/validator.php
@@ -162,7 +162,7 @@ final class Validate extends Command
                         }
                     }
 
-                    if (!isset($branch['time'])) {
+                    if (!array_key_exists('time', $branch)) {
                         $messages[$path][] = sprintf('Key "time" is required for branch "%s".', $name);
                     }
 


### PR DESCRIPTION
Alternative to #242. I don't think we need the `unfixed` entry. Having a `time` set as `null` is semantically enough.

/cc @paragonie-scott @stof