### PR TITLE
Add advisory for Parsedown

### DIFF
--- a/erusev/parsedown/2017-05-01.yaml
+++ b/erusev/parsedown/2017-05-01.yaml
@@ -1,0 +1,7 @@
+title:     Cross-Site Scripting
+link:      https://github.com/erusev/parsedown/pull/495
+branches:
+    1.x:
+        time:     ~
+        versions: ['<=1.6.4']
+reference: composer://erusev/parsedown


### PR DESCRIPTION
Parsedown has had multiple XSS issues for a long time when using its `->setMarkupEscaped(true)` option (e.g. being able to break out of the AST representation by adding quotes in link ~~addresses~~ titles). All of these issues are fixed in https://github.com/erusev/parsedown/pull/495, but this has remained open for almost a year now, and there appears to be no interest in merging it any time soon from the repository owner (I digress).

There might be some debate as to whether XSS issues in a markdown parser can actually be considered security issues (since markdown itself permits HTML). To address this I would present the following:
* The Parsedown Wiki has for a long time [stated](https://github.com/erusev/parsedown/wiki/Tutorial:-Get-Started/f9d881da38d8ef737ffc0c0a140b124ba3367904) that HTML can be escaped using the `->setMarkupEscaped(true)` configuration:
  > ```php
  >   echo Parsedown::instance()
  >      ->setMarkupEscaped(true) # escapes markup (HTML)
  >      ->text("<div><strong>*Some text*</strong></div>");
  >
  >   # Output:
  >   # <p>&lt;div&gt;&lt;strong&gt;<em>Some text</em>&lt;/strong&gt;&lt;/div&gt;</p>
  >```

  (Parsedown does not do this properly)

* Attempts at escaping HTML appear throughout the code, but are not sufficient, or are applied in some places but missed in analogous ones (e.g. https://github.com/erusev/parsedown/pull/495#issuecomment-340721927)