### PR TITLE
erusev/parsedown 1.7.0 addresses advisory #257

### DIFF
--- a/erusev/parsedown/2017-05-01.yaml
+++ b/erusev/parsedown/2017-05-01.yaml
@@ -3,5 +3,5 @@ link:      https://github.com/erusev/parsedown/pull/495
 branches:
     1.x:
         time:     ~
-        versions: ['<=1.6.4']
+        versions: ['<1.7.0']
 reference: composer://erusev/parsedown


### PR DESCRIPTION
As requested in https://github.com/FriendsOfPHP/security-advisories/pull/257#issuecomment-369240396