### PR TITLE
Adjust report version range

### DIFF
--- a/pagarme/pagarme-php/2017-11-20.yaml
+++ b/pagarme/pagarme-php/2017-11-20.yaml
@@ -2,7 +2,7 @@ title:      Padding Oracle Vulnerability in RSA Encryption
 link:       https://github.com/pagarme/pagarme-php/issues/29
 cve:        ~
 branches:
-    3.x:
+    2.x:
         time:     ~
-        versions: ['>=0.0.0', '<9.9.99']
+        versions: ['>=0.0.0', '<3.0.0']
 reference: composer://pagarme/pagarme-php


### PR DESCRIPTION
Looking at the code I see that the security issue about
[pagarme/pagarme-php](https://github.com/pagarme/pagarme-php) reported
in #241 only appears on versions below 3.x. Since the stable version (on
branch V3) doesn't have the vulnerability this PR aims to fix the
version range.