### PR TITLE
Drupal advisory SA-CORE-2018-001 (for drupla/drupal module)

### DIFF
--- a/drupal/drupal/CVE-2017-6926.yaml
+++ b/drupal/drupal/CVE-2017-6926.yaml
@@ -17,4 +17,4 @@ branches:
     8.4.x:
         time:     2018-02-20 21:35:13
         versions: ['>=8.4.0','<8.4.5']
-reference: composer://drupal/core
+reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2017-6926.yaml
+++ b/drupal/drupal/CVE-2017-6926.yaml
@@ -1,0 +1,20 @@
+title:     Comment reply form allows access to restricted content.
+link:      https://www.drupal.org/SA-CORE-2018-001
+cve:       CVE-2017-6926
+branches:
+    8.0.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.4.0','<8.4.5']
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2017-6927.yaml
+++ b/drupal/drupal/CVE-2017-6927.yaml
@@ -1,0 +1,20 @@
+title:     JavaScript cross-site scripting prevention is incomplete.
+link:      https://www.drupal.org/SA-CORE-2018-001
+cve:       CVE-2017-6927
+branches:
+    8.0.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.4.0','<8.4.5']
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2017-6927.yaml
+++ b/drupal/drupal/CVE-2017-6927.yaml
@@ -17,4 +17,4 @@ branches:
     8.4.x:
         time:     2018-02-20 21:35:13
         versions: ['>=8.4.0','<8.4.5']
-reference: composer://drupal/core
+reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2017-6928.yaml
+++ b/drupal/drupal/CVE-2017-6928.yaml
@@ -1,0 +1,20 @@
+title:     Private file access bypass.
+link:      https://www.drupal.org/SA-CORE-2018-001
+cve:       CVE-2017-6928
+branches:
+    8.0.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.4.0','<8.4.5']
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2017-6928.yaml
+++ b/drupal/drupal/CVE-2017-6928.yaml
@@ -17,4 +17,4 @@ branches:
     8.4.x:
         time:     2018-02-20 21:35:13
         versions: ['>=8.4.0','<8.4.5']
-reference: composer://drupal/core
+reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2017-6929.yaml
+++ b/drupal/drupal/CVE-2017-6929.yaml
@@ -1,0 +1,20 @@
+title:     jQuery vulnerability with untrusted domains.
+link:      https://www.drupal.org/SA-CORE-2018-001
+cve:       CVE-2017-6929
+branches:
+    8.0.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.4.0','<8.4.5']
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2017-6929.yaml
+++ b/drupal/drupal/CVE-2017-6929.yaml
@@ -17,4 +17,4 @@ branches:
     8.4.x:
         time:     2018-02-20 21:35:13
         versions: ['>=8.4.0','<8.4.5']
-reference: composer://drupal/core
+reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2017-6930.yaml
+++ b/drupal/drupal/CVE-2017-6930.yaml
@@ -17,4 +17,4 @@ branches:
     8.4.x:
         time:     2018-02-20 21:35:13
         versions: ['>=8.4.0','<8.4.5']
-reference: composer://drupal/core
+reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2017-6930.yaml
+++ b/drupal/drupal/CVE-2017-6930.yaml
@@ -1,0 +1,20 @@
+title:     Language fallback can be incorrect on multilingual sites with node access restrictions.
+link:      https://www.drupal.org/SA-CORE-2018-001
+cve:       CVE-2017-6930
+branches:
+    8.0.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.4.0','<8.4.5']
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2017-6931.yaml
+++ b/drupal/drupal/CVE-2017-6931.yaml
@@ -1,0 +1,20 @@
+title:     Settings Tray access bypass.
+link:      https://www.drupal.org/SA-CORE-2018-001
+cve:       CVE-2017-6931
+branches:
+    8.0.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.4.0','<8.4.5']
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2017-6931.yaml
+++ b/drupal/drupal/CVE-2017-6931.yaml
@@ -17,4 +17,4 @@ branches:
     8.4.x:
         time:     2018-02-20 21:35:13
         versions: ['>=8.4.0','<8.4.5']
-reference: composer://drupal/core
+reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2017-6932.yaml
+++ b/drupal/drupal/CVE-2017-6932.yaml
@@ -1,0 +1,20 @@
+title:     External link injection on 404 pages when linking to the current page.
+link:      https://www.drupal.org/SA-CORE-2018-001
+cve:       CVE-2017-6932
+branches:
+    8.0.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.0','<8.1.0']
+    8.1.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     2018-02-20 21:35:13
+        versions: ['>=8.4.0','<8.4.5']
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2017-6932.yaml
+++ b/drupal/drupal/CVE-2017-6932.yaml
@@ -17,4 +17,4 @@ branches:
     8.4.x:
         time:     2018-02-20 21:35:13
         versions: ['>=8.4.0','<8.4.5']
-reference: composer://drupal/core
+reference: composer://drupal/drupal


### PR DESCRIPTION
Forgot "drupla/drupal" in the previous pull request.
CVE-2017-6926
CVE-2017-6927
CVE-2017-6928
CVE-2017-6929
CVE-2017-6930
CVE-2017-6931
CVE-2017-6932