### PR TITLE
Create 201803-01.yaml

### DIFF
--- a/simplesamlphp/simplesamlphp/201803-01.yaml
+++ b/simplesamlphp/simplesamlphp/201803-01.yaml
@@ -2,6 +2,6 @@ title:     Incorrect signature verification
 link:      https://simplesamlphp.org/security/201803-01
 branches:
     1.15.x:
-        time:     2018-03-02 16:02:00
+        time:     2018-03-02 15:02:24
         versions: ['<1.15.4']
 reference: composer://simplesamlphp/simplesamlphp

--- a/simplesamlphp/simplesamlphp/201803-01.yaml
+++ b/simplesamlphp/simplesamlphp/201803-01.yaml
@@ -1,0 +1,7 @@
+title:     Incorrect signature verification
+link:      https://simplesamlphp.org/security/201803-01
+branches:
+    1.15.x:
+        time:     2018-03-02 16:02:00
+        versions: ['<1.15.4']
+reference: composer://simplesamlphp/simplesamlphp


### PR DESCRIPTION
I'm not sure I have the time exactly as it should be. The example I looked at didn't match to the second (it used `00` for the second, so I did as well), but someone familiar with submitting these should probably check that date/time value.

This security advisory also affected simplesamlphp/saml2, but unfortunately I don't have time to submit a file for that path at the moment.