### PR TITLE
Add advisory for squizlabs/php_codesniffer 3.0.0

### DIFF
--- a/squizlabs/php_codesniffer/2017-05-18.yaml
+++ b/squizlabs/php_codesniffer/2017-05-18.yaml
@@ -1,0 +1,8 @@
+title:     Arbitrary shell execution
+link:      https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.0.1
+cve:       ~
+branches:
+    3.0.x:
+        time:     2017-05-18 04:24:49
+        versions: ['>=3.0.0', '<3.0.1']
+reference: composer://squizlabs/php_codesniffer


### PR DESCRIPTION
See: https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.0.1

~~Time based on when the fix was originally pulled to PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/pull/1475~~

Updated to reflect the time when the fix was originally *merged* into PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/commit/7ce7bb942f5667724e81a3ea99e805a30be6c05b