### PR TITLE
Fix `time` in advisory for squizlabs/php_codesniffer < 2.8.1

### DIFF
--- a/squizlabs/php_codesniffer/2017-03-01.yaml
+++ b/squizlabs/php_codesniffer/2017-03-01.yaml
@@ -4,9 +4,9 @@ cve:       ~
 branches:
     # The 1.x branch is unsupported, mark all versions as vulnerable.
     1.x:
-        time:     2017-01-03 22:17:45
+        time:     2017-02-26 22:15:53
         versions: ['>=1.0.0', '<2.0.0']
     2.x:
-        time:     2017-01-03 22:17:45
+        time:     2017-02-26 22:15:53
         versions: ['>=2.0.0', '<2.8.1']
 reference: composer://squizlabs/php_codesniffer


### PR DESCRIPTION
The date/time of the issue was in an incorrect format (`2017-01-03` vs `2017-03-01`).

As I was fixing this anyway, I checked the actual time of the commit fixing this which can be seen as the first public announcement of the vulnerability.

So the new time is based on when the fix was originally committed to PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/commit/029305e754dde022c4c8ee48d392c16b61fffe2a