### PR TITLE
Drupal SA-CORE-2018-002

### DIFF
--- a/drupal/core/CVE-2018-7600.yaml
+++ b/drupal/core/CVE-2018-7600.yaml
@@ -1,0 +1,17 @@
+title: Highly critical - Remote Code Execution 
+link: https://www.drupal.org/sa-core-2018-002
+cve: CVE-2018-7600
+branches:
+    7.x:
+        time:     2018-03-28 19:30:00
+        versions: ['>=7.0','<7.58']
+    8.3.x:
+        time:     2018-03-28 19:30:00
+        versions: ['>=8.0','<8.3.9']
+    8.4.x:
+        time:     2018-03-28 19:30:00
+        versions: ['>=8.4','<8.4.6']
+    8.5.x:
+        time:     2018-03-28 19:30:00
+        versions: ['>=8.5','<8.5.1']
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2018-7600.yaml
+++ b/drupal/drupal/CVE-2018-7600.yaml
@@ -14,4 +14,4 @@ branches:
     8.5.x:
         time:     2018-03-28 19:30:00
         versions: ['>=8.5','<8.5.1']
-reference: composer://drupal/core
+reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2018-7600.yaml
+++ b/drupal/drupal/CVE-2018-7600.yaml
@@ -1,0 +1,17 @@
+title: Highly critical - Remote Code Execution 
+link: https://www.drupal.org/sa-core-2018-002
+cve: CVE-2018-7600
+branches:
+    7.x:
+        time:     2018-03-28 19:30:00
+        versions: ['>=7.0','<7.58']
+    8.3.x:
+        time:     2018-03-28 19:30:00
+        versions: ['>=8.0','<8.3.9']
+    8.4.x:
+        time:     2018-03-28 19:30:00
+        versions: ['>=8.4','<8.4.6']
+    8.5.x:
+        time:     2018-03-28 19:30:00
+        versions: ['>=8.5','<8.5.1']
+reference: composer://drupal/core


### PR DESCRIPTION
https://www.drupal.org/sa-core-2018-002

Mirrored patches:

Drupal 6: https://gist.github.com/paragonie-scott/dca4690a504a1d860575041eb274eeef

Drupal 7: https://gist.github.com/paragonie-scott/79ddffd734bf15a9d86b723d74d15572

Drupal 8: https://gist.github.com/paragonie-scott/ee034dc43cbaafb9ff1cfcdda77d3240

The actual mitigation of these patches: https://gist.github.com/paragonie-scott/79ddffd734bf15a9d86b723d74d15572#file-drupal-7-x-2018-002-patch-L91

Explanation: https://twitter.com/codeincarnate/status/979080318966730753

> Drupal uses the hash "#" at the beginning of array keys to signify special keys usually that lead to some type of computation. Basically you can inject these. See Drupal form API for example