### PR TITLE
CVE-2017-9303 for laravel auth

### DIFF
--- a/illuminate/auth/CVE-2017-9303.yaml
+++ b/illuminate/auth/CVE-2017-9303.yaml
@@ -1,0 +1,11 @@
+title:     Password reset phishing vulnerability
+link:      https://laravel.com/docs/5.4/releases#laravel-5.4.22
+cve:       CVE-2017-9303
+branches:
+    5.3.x:
+        time:     ~
+        versions: ['>=5.3.0', '<=5.3.31']
+    5.4.x:
+        time:     2017-05-07 17:49:26
+        versions: ['>=5.4.0', '<5.4.22']
+reference: composer://illuminate/auth

--- a/laravel/framework/CVE-2017-9303.yaml
+++ b/laravel/framework/CVE-2017-9303.yaml
@@ -1,0 +1,11 @@
+title:     Password reset phishing vulnerability
+link:      https://laravel.com/docs/5.4/releases#laravel-5.4.22
+cve:       CVE-2017-9303
+branches:
+    5.3.x:
+        time:     ~
+        versions: ['>=5.3.0', '<=5.3.31']
+    5.4.x:
+        time:     2017-05-07 17:49:26
+        versions: ['>=5.4.0', '<5.4.22']
+reference: composer://laravel/framework


### PR DESCRIPTION
- Listed in the CVE database under [CVE-20170-9303](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9303). 
- Documented at [Laravel 5.4 releases](https://laravel.com/docs/5.4/releases#laravel-5.4.22). 
- Fixed with commit [#cef1055](https://github.com/laravel/framework/commit/cef10551820530632a86fa6f1306fee95c5cac43).