### PR TITLE
CVE-2017-14775 for laravel auth

### DIFF
--- a/illuminate/auth/CVE-2017-14775.yaml
+++ b/illuminate/auth/CVE-2017-14775.yaml
@@ -1,0 +1,29 @@
+title:     Timing attack vector for remember me token
+link:      https://github.com/laravel/framework/pull/21320
+cve:       CVE-2017-14775
+branches:
+    4.1.x:
+        time:     ~
+        versions: ['>=4.1.26', '<=4.1.31']
+    4.2.x:
+        time:     ~
+        versions: ['>=4.2.0', '<=4.2.22']
+    5.0.x:
+        time:     ~
+        versions: ['>=5.0.0', '<=5.0.35']
+    5.1.x:
+        time:     ~
+        versions: ['>=5.1.0', '<=5.1.46']
+    5.2.x:
+        time:     ~
+        versions: ['>=5.2.0', '<=5.2.45']
+    5.3.x:
+        time:     ~
+        versions: ['>=5.3.0', '<=5.3.31']
+    5.4.x:
+        time:     ~
+        versions: ['>=5.4.0', '<=5.4.36']
+    5.5.x:
+        time:     2017-09-21 01:38:58
+        versions: ['>=5.5.0', '<5.5.10']
+reference: composer://illuminate/auth

--- a/laravel/framework/CVE-2017-14775.yaml
+++ b/laravel/framework/CVE-2017-14775.yaml
@@ -1,0 +1,29 @@
+title:     Timing attack vector for remember me token
+link:      https://github.com/laravel/framework/pull/21320
+cve:       CVE-2017-14775
+branches:
+    4.1.x:
+        time:     ~
+        versions: ['>=4.1.26', '<=4.1.31']
+    4.2.x:
+        time:     ~
+        versions: ['>=4.2.0', '<=4.2.22']
+    5.0.x:
+        time:     ~
+        versions: ['>=5.0.0', '<=5.0.35']
+    5.1.x:
+        time:     ~
+        versions: ['>=5.1.0', '<=5.1.46']
+    5.2.x:
+        time:     ~
+        versions: ['>=5.2.0', '<=5.2.45']
+    5.3.x:
+        time:     ~
+        versions: ['>=5.3.0', '<=5.3.31']
+    5.4.x:
+        time:     ~
+        versions: ['>=5.4.0', '<=5.4.36']
+    5.5.x:
+        time:     2017-09-21 01:38:58
+        versions: ['>=5.5.0', '<5.5.10']
+reference: composer://laravel/framework


### PR DESCRIPTION
- Listed in the CVE database under [CVE-20170-14775](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14775). 
- Documented (and fixed) at [Laravel PR#21320](https://github.com/laravel/framework/pull/21320). 