### PR TITLE
Paypal and Slim.

### DIFF
--- a/paypal/merchant-sdk-php/CVE-2017-6099.yaml
+++ b/paypal/merchant-sdk-php/CVE-2017-6099.yaml
@@ -4,7 +4,7 @@ cve:       CVE-2017-6099
 branches:
     2.x:
         time:     2017-03-31, 
-        versions: ['<2.1.96']
+        versions: ['<=2.11.118']
     master:
         time:     2017-03-31, 
         versions: ['<3.10.0']

--- a/paypal/merchant-sdk-php/CVE-2017-6099.yaml
+++ b/paypal/merchant-sdk-php/CVE-2017-6099.yaml
@@ -4,8 +4,8 @@ cve:       CVE-2017-6099
 branches:
     2.x:
         time:     ~
-        versions: ['>=2.0.0', '<=2.11.118']
+        versions: ['<3.0']
     master:
         time:     2017-03-29 16:13:00
-        versions: ['>=3.0.0', '<3.10.0']
+        versions: ['>=3.0.0', '<3.12.0']
 reference: composer://paypal/merchant-sdk-php

--- a/paypal/merchant-sdk-php/CVE-2017-6099.yaml
+++ b/paypal/merchant-sdk-php/CVE-2017-6099.yaml
@@ -2,7 +2,10 @@ title:     Cross-site scripting (XSS) vulnerability in Paypal-Merchant-SDK-PHP
 link:      https://github.com/paypal/merchant-sdk-php/tree/v3.9.1
 cve:       CVE-2017-6099
 branches:
+    2.x:
+        time:     2017-03-31, 
+        versions: ['<2.1.96']
     master:
         time:     2017-03-31, 
-        versions: ['>=3.9.1', '<3.10.0']
+        versions: ['<3.10.0']
 reference: composer://paypal/merchant-sdk-php

--- a/paypal/merchant-sdk-php/CVE-2017-6099.yaml
+++ b/paypal/merchant-sdk-php/CVE-2017-6099.yaml
@@ -6,6 +6,6 @@ branches:
         time:     ~
         versions: ['>=2.0.0', '<=2.11.118']
     master:
-        time:     2017-03-31 08:33:00
+        time:     2017-03-29 16:13:00
         versions: ['>=3.0.0', '<3.10.0']
 reference: composer://paypal/merchant-sdk-php

--- a/paypal/merchant-sdk-php/CVE-2017-6099.yaml
+++ b/paypal/merchant-sdk-php/CVE-2017-6099.yaml
@@ -3,9 +3,9 @@ link:      https://github.com/paypal/merchant-sdk-php/tree/v3.9.1
 cve:       CVE-2017-6099
 branches:
     2.x:
-        time:     2017-03-31, 
-        versions: ['<=2.11.118']
+        time:     ~,
+        versions: ['>=2.0.0', '<=2.11.118']
     master:
         time:     2017-03-31, 
-        versions: ['<3.10.0']
+        versions: ['>=3.0.0', '<3.10.0']
 reference: composer://paypal/merchant-sdk-php

--- a/paypal/merchant-sdk-php/CVE-2017-6099.yaml
+++ b/paypal/merchant-sdk-php/CVE-2017-6099.yaml
@@ -1,0 +1,8 @@
+title:     Cross-site scripting (XSS) vulnerability in Paypal-Merchant-SDK-PHP
+link:      https://github.com/paypal/merchant-sdk-php/tree/v3.9.1
+cve:       CVE-2017-6099
+branches:
+    master:
+        time:     2017-03-31, 
+        versions: ['>=3.9.1', '<3.10.0']
+reference: composer://paypal/merchant-sdk-php

--- a/paypal/merchant-sdk-php/CVE-2017-6099.yaml
+++ b/paypal/merchant-sdk-php/CVE-2017-6099.yaml
@@ -3,9 +3,9 @@ link:      https://github.com/paypal/merchant-sdk-php/tree/v3.9.1
 cve:       CVE-2017-6099
 branches:
     2.x:
-        time:     ~,
+        time:     ~
         versions: ['>=2.0.0', '<=2.11.118']
     master:
-        time:     2017-03-31, 
+        time:     2017-03-31 08:33:00
         versions: ['>=3.0.0', '<3.10.0']
 reference: composer://paypal/merchant-sdk-php

--- a/slim/slim/CVE-2015-2171.yaml
+++ b/slim/slim/CVE-2015-2171.yaml
@@ -1,4 +1,4 @@
-title:     Conducting PHP object injection attacks and execute arbitrary PHP code via crafted session data.
+title:     PHP object injection attack vulnerability in Slim.
 link:      https://github.com/slimphp/Slim/issues/1034
 cve:       CVE-2015-2171
 branches:

--- a/slim/slim/CVE-2015-2171.yaml
+++ b/slim/slim/CVE-2015-2171.yaml
@@ -1,0 +1,8 @@
+title:     Conducting PHP object injection attacks and execute arbitrary PHP code via crafted session data.
+link:      https://github.com/slimphp/Slim/issues/1034
+cve:       CVE-2015-2171
+branches:
+    2.x:
+        time:     2015-03-01,
+        versions: ['<2.6.0']
+reference: composer://slim/slim

--- a/slim/slim/CVE-2015-2171.yaml
+++ b/slim/slim/CVE-2015-2171.yaml
@@ -3,6 +3,6 @@ link:      https://github.com/slimphp/Slim/issues/1034
 cve:       CVE-2015-2171
 branches:
     2.x:
-        time:     2015-03-01,
+        time:     2015-03-01 09:13:00
         versions: ['<2.6.0']
 reference: composer://slim/slim


### PR DESCRIPTION
- CVE-2017-6099 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-6099>.
- CVE-2015-2171 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-2171>.

paypal/merchant-sdk-php:
Cross-site scripting (XSS) vulnerability in GetAuthDetails.html.php in PayPal PHP Merchant SDK (aka merchant-sdk-php) 3.9.1 allows remote attackers to inject arbitrary web script or HTML via the token parameter.

slim/slim:
Middleware/SessionCookie.php in Slim before 2.6.0 allows remote attackers to conduct PHP object injection attacks and execute arbitrary PHP code via crafted session data.