### PR TITLE
Create CVE-2018-1000025.yaml

### DIFF
--- a/kreait/firebase-php/CVE-2018-1000025.yaml
+++ b/kreait/firebase-php/CVE-2018-1000025.yaml
@@ -4,5 +4,5 @@ cve:       CVE-2018-1000025
 branches:
     master:
         time:     2018-01-16 10:51:00
-        versions: ['>=3.2.0', '<3.8.0']
+        versions: ['>=3.2.0', '<3.8.1']
 reference: composer://kreait/firebase-php


### PR DESCRIPTION
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000025

Jerome Gamez Firebase Admin SDK for PHP version from 3.2.0 to 3.8.0 contains a Incorrect Access Control vulnerability in src/Firebase/Auth/IdTokenVerifier.php does not verify for token signature that can result in JWT with any email address and user ID could be forged from an actual token, or from thin air. This attack appear to be exploitable via Attacker would only need to know email address of the victim on most cases.. This vulnerability appears to have been fixed in 3.8.1.