### PR TITLE
replace advisory link with actual issue URL

### DIFF
--- a/paypal/merchant-sdk-php/CVE-2017-6099.yaml
+++ b/paypal/merchant-sdk-php/CVE-2017-6099.yaml
@@ -1,5 +1,5 @@
 title:     Cross-site scripting (XSS) vulnerability in Paypal-Merchant-SDK-PHP
-link:      https://github.com/paypal/merchant-sdk-php/tree/v3.9.1
+link:      https://github.com/paypal/merchant-sdk-php/issues/129
 cve:       CVE-2017-6099
 branches:
     2.x:


### PR DESCRIPTION
Instead of referencing the affected version tag it's probably better to link to the real issue description.

ping @ularanigu