### PR TITLE
Add CVE for Parsedown vulnerability

### DIFF
--- a/erusev/parsedown/2017-05-01.yaml
+++ b/erusev/parsedown/2017-05-01.yaml
@@ -1,5 +1,6 @@
 title:     Cross-Site Scripting
 link:      https://github.com/erusev/parsedown/pull/495
+cve:       CVE-2018-1000162
 branches:
     1.x:
         time:     ~


### PR DESCRIPTION
A [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000162) was assigned for this issue.