### PR TITLE
Rename magento2

### DIFF
--- a/magento/magento2ce/2016-07-19.yaml
+++ b/magento/magento2ce/2016-07-19.yaml
@@ -1,6 +1,6 @@
 title:     Unauthenticated crypto and weak IV in Magento\Framework\Encryption
 link:      http://www.openwall.com/lists/oss-security/2016/07/19/3
-cve:       ~
+cve:       CVE-2016-6485
 branches:
     "2.0":
         time:     2014-02-13 11:12:34
@@ -10,6 +10,6 @@ branches:
         versions: ['>=2.1', '<2.2']
     "2.2":
         time:     2014-02-13 11:12:34
-        versions: ['>=2.2', '<2.3']
+        versions: ['>=2.2', '<2.2.5']
 reference: composer://magento/magento2ce
 composer-repository: false

--- a/magento/product-community-edition/2016-07-19.yaml
+++ b/magento/product-community-edition/2016-07-19.yaml
@@ -11,5 +11,5 @@ branches:
     "2.2":
         time:     2014-02-13 11:12:34
         versions: ['>=2.2', '<2.2.5']
-reference: composer://magento/magento2ce
+reference: composer://magento/product-community-edition
 composer-repository: false

--- a/magento/product-community-edition/2018-06-27.yaml
+++ b/magento/product-community-edition/2018-06-27.yaml
@@ -8,5 +8,5 @@ branches:
     "2.2":
         time:     2018-06-27 00:00:00
         versions: ['>=2.2', '<2.2.5']
-reference: composer://magento/magento2ce
+reference: composer://magento/product-community-edition
 composer-repository: false


### PR DESCRIPTION
This replaces #303 and #305 and fixes the package name, as it's used by regular magento2 community projects.