### PR TITLE
[TASK] Add TYPO3-CORE-SA-2018-001 to TYPO3-CORE-SA-2018-004

### DIFF
--- a/typo3/cms-core/2018-07-12-1.yaml
+++ b/typo3/cms-core/2018-07-12-1.yaml
@@ -1,0 +1,10 @@
+title:     Authentication Bypass in TYPO3 CMS
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-001/
+branches:
+    8.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=8.0.0', '<8.7.17']
+    9.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=9.0.0', '<9.3.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-07-12-2.yaml
+++ b/typo3/cms-core/2018-07-12-2.yaml
@@ -1,0 +1,10 @@
+title:     Insecure Deserialization & Arbitrary Code Execution in TYPO3 CMS
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-002/
+branches:
+    8.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=8.0.0', '<8.7.17']
+    9.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=9.0.0', '<9.3.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-07-12-3.yaml
+++ b/typo3/cms-core/2018-07-12-3.yaml
@@ -1,0 +1,10 @@
+title:     Privilege Escalation & SQL Injection in TYPO3 CMS
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-003/
+branches:
+    8.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=8.5.0', '<8.7.17']
+    9.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=9.0.0', '<9.3.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-07-12-4.yaml
+++ b/typo3/cms-core/2018-07-12-4.yaml
@@ -1,0 +1,10 @@
+title:     Insecure Deserialization in TYPO3 CMS
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-004/
+branches:
+    8.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=8.5.0', '<8.7.17']
+    9.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=9.0.0', '<9.3.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms/2018-07-12-1.yaml
+++ b/typo3/cms/2018-07-12-1.yaml
@@ -1,0 +1,13 @@
+title:     Authentication Bypass in TYPO3 CMS
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-001/
+branches:
+    7.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=7.0.0', '<7.6.30']
+    8.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=8.0.0', '<8.7.17']
+    9.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=9.0.0', '<9.3.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-07-12-2.yaml
+++ b/typo3/cms/2018-07-12-2.yaml
@@ -1,0 +1,13 @@
+title:     Insecure Deserialization & Arbitrary Code Execution in TYPO3 CMS
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-002/
+branches:
+    7.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=7.0.0', '<7.6.30']
+    8.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=8.0.0', '<8.7.17']
+    9.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=9.0.0', '<9.3.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-07-12-3.yaml
+++ b/typo3/cms/2018-07-12-3.yaml
@@ -1,0 +1,10 @@
+title:     Privilege Escalation & SQL Injection in TYPO3 CMS
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-003/
+branches:
+    8.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=8.5.0', '<8.7.17']
+    9.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=9.0.0', '<9.3.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-07-12-4.yaml
+++ b/typo3/cms/2018-07-12-4.yaml
@@ -1,0 +1,10 @@
+title:     Insecure Deserialization in TYPO3 CMS
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-004/
+branches:
+    8.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=8.5.0', '<8.7.17']
+    9.x:
+        time:     2018-07-12 09:34:56
+        versions: ['>=9.0.0', '<9.3.2']
+reference: composer://typo3/cms


### PR DESCRIPTION
* https://typo3.org/security/advisory/typo3-core-sa-2018-001/
* https://typo3.org/security/advisory/typo3-core-sa-2018-002/
* https://typo3.org/security/advisory/typo3-core-sa-2018-003/
* https://typo3.org/security/advisory/typo3-core-sa-2018-004/

Package "typo3/cms" addresses legacy packages, "typo3/cms-core"
addresses the sub-tree split packages since v8.x, which became
a mandatory package in v9.0.0.