### PR TITLE
Add advisory for Laravel cookie serialization vulnerability

### DIFF
--- a/illuminate/cookie/2018-08-08-1.yaml
+++ b/illuminate/cookie/2018-08-08-1.yaml
@@ -1,0 +1,35 @@
+title:     Cookie serialization vulnerability
+link:      https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30
+cve:       ~
+branches:
+    4.0.x:
+        time:     ~
+        versions: ['>=4.0.0', '<=4.0.11']
+    4.1.x:
+        time:     ~
+        versions: ['>=4.1.0', '<=4.1.31']
+    4.2.x:
+        time:     ~
+        versions: ['>=4.2.0', '<=4.2.22']
+    5.0.x:
+        time:     ~
+        versions: ['>=5.0.0', '<=5.0.35']
+    5.1.x:
+        time:     ~
+        versions: ['>=5.1.0', '<=5.1.46']
+    5.2.x:
+        time:     ~
+        versions: ['>=5.2.0', '<=5.2.45']
+    5.3.x:
+        time:     ~
+        versions: ['>=5.3.0', '<=5.3.31']
+    5.4.x:
+        time:     ~
+        versions: ['>=5.4.0', '<=5.4.36']
+    5.5.x:
+        time:     2018-08-07 18:07:12
+        versions: ['>=5.5.0', '<5.5.42']
+    5.6.x:
+        time:     2018-08-07 07:53:14
+        versions: ['>=5.6.0', '<5.6.30']
+reference: composer://illuminate/cookie

--- a/laravel/framework/2018-08-08-1.yaml
+++ b/laravel/framework/2018-08-08-1.yaml
@@ -1,0 +1,35 @@
+title:     Cookie serialization vulnerability
+link:      https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30
+cve:       ~
+branches:
+    4.0.x:
+        time:     ~
+        versions: ['>=4.0.0', '<=4.0.11']
+    4.1.x:
+        time:     ~
+        versions: ['>=4.1.0', '<=4.1.31']
+    4.2.x:
+        time:     ~
+        versions: ['>=4.2.0', '<=4.2.22']
+    5.0.x:
+        time:     ~
+        versions: ['>=5.0.0', '<=5.0.35']
+    5.1.x:
+        time:     ~
+        versions: ['>=5.1.0', '<=5.1.46']
+    5.2.x:
+        time:     ~
+        versions: ['>=5.2.0', '<=5.2.45']
+    5.3.x:
+        time:     ~
+        versions: ['>=5.3.0', '<=5.3.31']
+    5.4.x:
+        time:     ~
+        versions: ['>=5.4.0', '<=5.4.36']
+    5.5.x:
+        time:     2018-08-07 18:07:12
+        versions: ['>=5.5.0', '<5.5.42']
+    5.6.x:
+        time:     2018-08-07 07:53:14
+        versions: ['>=5.6.0', '<5.6.30']
+reference: composer://laravel/framework


### PR DESCRIPTION
As mentioned in the [official docs](https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30) and [Laravel News](https://laravel-news.com/laravel-5-6-30). The merged pull request containing the fix for `5.6.x` branch is [over here](https://github.com/laravel/framework/pull/25121). And the commit for the `5.5.x` branch is either [this one](https://github.com/laravel/framework/commit/c5dc9c870a8a1af6c7e827dd81bd15f0a1561cc4), the [parent of that one](https://github.com/laravel/framework/commit/6df8767c657b5b14bb8ac23b4858f9f8def0cb3c) or the [parent-of-the-parent](https://github.com/laravel/framework/commit/3716d145b60150c1f86c25b4004390a23d8328ea).