### PR TITLE
Add CVE for openid/php-openid

### DIFF
--- a/openid/php-openid/CVE-2013-4701.yaml
+++ b/openid/php-openid/CVE-2013-4701.yaml
@@ -1,0 +1,8 @@
+title:     XML External Entity (XXE) issue
+link:      https://github.com/openid/php-openid/commit/625c16bb28bb120d262b3f19f89c2c06cb9b0da9
+cve:       CVE-2013-4701
+branches:
+    2.x:
+        time:     2013-08-12 01:41:28
+        versions: ['<2.3.0']
+reference: composer://openid/php-openid


### PR DESCRIPTION
Note that I explicitly didn't include CVE-2016-2049, which is still unfixed (https://github.com/openid/php-openid/issues/128).
