### PR TITLE
Add CVE-2018-13982: Smarty Trusted-Directory Bypass via Path Traversal

### DIFF
--- a/smarty/smarty/CVE-2018-13982.yaml
+++ b/smarty/smarty/CVE-2018-13982.yaml
@@ -1,0 +1,8 @@
+title:     Trusted-Directory Bypass via Path Traversal
+link:      https://github.com/sbaresearch/advisories/tree/public/2018/SBA-ADV-20180420-01_Smarty_Path_Traversal
+cve:       CVE-2018-13982
+branches:
+    master:
+        time:       2018-04-26 19:38:08
+        versions:   ['<3.1.33']
+reference: composer://smarty/smarty


### PR DESCRIPTION
Security advisory: https://github.com/sbaresearch/advisories/tree/public/2018/SBA-ADV-20180420-01_Smarty_Path_Traversal