### PR TITLE
Add easy-admin extension bundle security flaw

### DIFF
--- a/alterphp/easyadmin-extension-bundle/2018-10-02.yaml
+++ b/alterphp/easyadmin-extension-bundle/2018-10-02.yaml
@@ -1,0 +1,11 @@
+title:     Action case insensitivity 
+link:      https://github.com/alterphp/EasyAdminExtensionBundle/releases/tag/v1.3.1
+cve:       ~
+branches:
+    1.3.x:
+        time:     2018-10-02 00:01:00
+        versions: ['>=1.3.0', '<1.3.1']
+    1.2.x:
+        time:     2018-10-02 00:01:00
+        versions: ['>=1.2.0', '<1.2.11']
+reference: composer://alterphp/easyadmin-extension-bundle


### PR DESCRIPTION
As mentioned here: https://github.com/alterphp/EasyAdminExtensionBundle/commit/68407ca5be644d1c53fb894453df951230afc6dc