### PR TITLE
Fix magento2  CVE version

### DIFF
--- a/magento/product-community-edition/2016-07-19.yaml
+++ b/magento/product-community-edition/2016-07-19.yaml
@@ -10,6 +10,6 @@ branches:
         versions: ['>=2.1', '<2.2']
     "2.2":
         time:     2018-06-27 14:12:00
-        versions: ['>=2.2', '<2.2.5']
+        versions: ['>=2.2', '<2.2.6']
 reference: composer://magento/product-community-edition
 composer-repository: false


### PR DESCRIPTION
This was supposed to be in 2.2.5 but apparently only released as 2.2.6:
https://github.com/magento/magento2/blob/2.2.5/lib/internal/Magento/Framework/Encryption/Crypt.php#L78
vs 
https://github.com/magento/magento2/blob/2.2.6/lib/internal/Magento/Framework/Encryption/Crypt.php#L78
(Re https://github.com/FriendsOfPHP/security-advisories/pull/161#issuecomment-402142322)