### PR TITLE
CVE-2018-17057

### DIFF
--- a/fooman/tcpdf/CVE-2018-17057.yaml
+++ b/fooman/tcpdf/CVE-2018-17057.yaml
@@ -3,6 +3,6 @@ link:      https://github.com/tecnickcom/TCPDF/commit/1861e33fe05f653b67d070f7c1
 cve:       CVE-2018-17057
 branches:
     master:
-        time:     2018-09-14 15:26:29Z
+        time:     2018-09-20 05:24:43Z
         versions: ['<6.2.22']
 reference: composer://fooman/tcpdf

--- a/fooman/tcpdf/CVE-2018-17057.yaml
+++ b/fooman/tcpdf/CVE-2018-17057.yaml
@@ -1,0 +1,8 @@
+title:     Attackers can trigger deserialization of arbitrary data via the phar:// wrapper.
+link:      https://github.com/tecnickcom/TCPDF/commit/1861e33fe05f653b67d070f7c106463e7a5c26ed
+cve:       CVE-2018-17057
+branches:
+    master:
+        time:     2018-09-14 15:26:29Z
+        versions: ['<6.2.22']
+reference: composer://fooman/tcpdf

--- a/fossar/tcpdf-parser/CVE-2018-17057.yaml
+++ b/fossar/tcpdf-parser/CVE-2018-17057.yaml
@@ -1,0 +1,8 @@
+title:     Attackers can trigger deserialization of arbitrary data via the phar:// wrapper.
+link:      https://github.com/tecnickcom/TCPDF/commit/1861e33fe05f653b67d070f7c106463e7a5c26ed
+cve:       CVE-2018-17057
+branches:
+    master:
+        time:     null
+        versions: ['<6.2.22']
+reference: composer://fossar/tcpdf

--- a/fossar/tcpdf-parser/CVE-2018-17057.yaml
+++ b/fossar/tcpdf-parser/CVE-2018-17057.yaml
@@ -5,4 +5,4 @@ branches:
     master:
         time:     null
         versions: ['<6.2.22']
-reference: composer://fossar/tcpdf
+reference: composer://fossar/tcpdf-parser

--- a/la-haute-societe/tcpdf/CVE-2018-17057.yaml
+++ b/la-haute-societe/tcpdf/CVE-2018-17057.yaml
@@ -1,0 +1,8 @@
+title:     Attackers can trigger deserialization of arbitrary data via the phar:// wrapper.
+link:      https://github.com/tecnickcom/TCPDF/commit/1861e33fe05f653b67d070f7c106463e7a5c26ed
+cve:       CVE-2018-17057
+branches:
+    master:
+        time:     null
+        versions: ['<6.2.22']
+reference: composer://la-haute-societe/tcpdf

--- a/spoonity/tcpdf/CVE-2018-17057.yaml
+++ b/spoonity/tcpdf/CVE-2018-17057.yaml
@@ -1,0 +1,8 @@
+title:     Attackers can trigger deserialization of arbitrary data via the phar:// wrapper.
+link:      https://github.com/tecnickcom/TCPDF/commit/1861e33fe05f653b67d070f7c106463e7a5c26ed
+cve:       CVE-2018-17057
+branches:
+    master:
+        time:     null
+        versions: ['<6.2.22']
+reference: composer://spoonity/tcpdf

--- a/tecnickcom/tcpdf/CVE-2018-17057.yaml
+++ b/tecnickcom/tcpdf/CVE-2018-17057.yaml
@@ -1,0 +1,8 @@
+title:     Attackers can trigger deserialization of arbitrary data via the phar:// wrapper.
+link:      https://github.com/tecnickcom/TCPDF/commit/1861e33fe05f653b67d070f7c106463e7a5c26ed
+cve:       CVE-2018-17057
+branches:
+    master:
+        time:     2018-09-14 15:26:29Z
+        versions: ['<6.2.22']
+reference: composer://tecnickcom/tcpdf

--- a/wallabag/tcpdf/CVE-2018-17057.yaml
+++ b/wallabag/tcpdf/CVE-2018-17057.yaml
@@ -1,0 +1,8 @@
+title:     Attackers can trigger deserialization of arbitrary data via the phar:// wrapper.
+link:      https://github.com/tecnickcom/TCPDF/commit/1861e33fe05f653b67d070f7c106463e7a5c26ed
+cve:       CVE-2018-17057
+branches:
+    master:
+        time:     null
+        versions: ['<6.2.22']
+reference: composer://wallabag/tcpdf


### PR DESCRIPTION
`fooman/tcpdf` is a fork of `tecnickcom/tcpdf`
Both are affected by CVE-2018-17057.