### PR TITLE
Create CVE-2018-19296.yaml

### DIFF
--- a/phpmailer/phpmailer/CVE-2018-19296.yaml
+++ b/phpmailer/phpmailer/CVE-2018-19296.yaml
@@ -1,0 +1,11 @@
+title:     Object injection
+link:      https://github.com/PHPMailer/PHPMailer/releases/tag/v6.0.6
+cve:       CVE-2018-19296
+branches:
+    5.x:
+        time:     2018-11-16 22:32:31
+        versions: ['>=5.0.0', '<5.2.27']
+    6.x:
+        time:     2017-07-26 00:41:32
+        versions: ['>=6.0.0', '<6.0.6']
+reference: composer://phpmailer/phpmailer


### PR DESCRIPTION
Add a spec for new PHPMailer CVE-2018-19296. I don't know for sure what the earliest version affected is, so have labelled it back to 5.0.

This affects the current 6.x branch and the deprecated 5.x branch - I'm not sure if the format I've used in the yaml is correct.