### PR TITLE
sync CVEs into symfony/security

### DIFF
--- a/symfony/security/CVE-2016-2403.yaml
+++ b/symfony/security/CVE-2016-2403.yaml
@@ -1,0 +1,11 @@
+title:     "CVE-2016-2403: Unauthorized access on a misconfigured Ldap server when using an empty password"
+link:      https://symfony.com/cve-2016-2403
+cve:       CVE-2016-2403
+branches:
+    2.8.x:
+        time:     2016-05-09 21:34:47
+        versions: ['>=2.8.0', '<2.8.6']
+    3.0.x:
+        time:     2016-05-09 21:35:23
+        versions: ['>=3.0.0', '<3.0.6']
+reference: composer://symfony/security

--- a/symfony/security/CVE-2016-4423.yaml
+++ b/symfony/security/CVE-2016-4423.yaml
@@ -1,0 +1,26 @@
+title:     "CVE-2016-4423: Large username storage in session"
+link:      https://symfony.com/cve-2016-4423
+cve:       CVE-2016-4423
+branches:
+    2.3.x:
+        time:     2016-05-09 21:13:10
+        versions: ['>=2.3.0', '<2.3.41']
+    2.4.x:
+        time:     2016-05-09 21:13:10
+        versions: ['>=2.4.0', '<2.5.0']
+    2.5.x:
+        time:     2016-05-09 21:13:10
+        versions: ['>=2.5.0', '<2.6.0']
+    2.6.x:
+        time:     2016-05-09 21:13:10
+        versions: ['>=2.6.0', '<2.7.0']
+    2.7.x:
+        time:     2016-05-09 21:21:30
+        versions: ['>=2.7.0', '<2.7.13']
+    2.8.x:
+        time:     2016-05-09 21:24:00
+        versions: ['>=2.8.0', '<2.8.6']
+    3.0.x:
+        time:     2016-05-09 21:31:02
+        versions: ['>=3.0.0', '<3.0.6']
+reference: composer://symfony/security

--- a/symfony/security/CVE-2017-16652.yaml
+++ b/symfony/security/CVE-2017-16652.yaml
@@ -1,0 +1,23 @@
+title:     "CVE-2017-16652: Open redirect vulnerability on security handlers"
+link:      https://symfony.com/cve-2017-16652
+cve:       CVE-2017-16652
+branches:
+    2.7.x:
+        time:     2017-11-16 15:16:56
+        versions: ['>=2.7.0', '<2.7.38']
+    2.8.x:
+        time:     2017-11-16 15:20:19
+        versions: ['>=2.8.0', '<2.8.31']
+    3.0.x:
+        time:     2017-11-16 15:14:44
+        versions: ['>=3.0.0', '<3.1.0']
+    3.1.x:
+        time:     2017-11-16 15:14:44
+        versions: ['>=3.1.0', '<3.2.0']
+    3.2.x:
+        time:     2017-11-16 15:17:32
+        versions: ['>=3.2.0', '<3.2.14']
+    3.3.x:
+        time:     2017-11-16 15:24:32
+        versions: ['>=3.3.0', '<3.3.13']
+reference: composer://symfony/security

--- a/symfony/security/CVE-2017-16653.yaml
+++ b/symfony/security/CVE-2017-16653.yaml
@@ -1,0 +1,23 @@
+title:     "CVE-2017-16653: CSRF protection does not use different tokens for HTTP and HTTPS"
+link:      https://symfony.com/cve-2017-16653
+cve:       CVE-2017-16653
+branches:
+    2.7.x:
+        time:     2017-11-16 15:12:07
+        versions: ['>=2.7.0', '<2.7.38']
+    2.8.x:
+        time:     2017-11-16 15:20:19
+        versions: ['>=2.8.0', '<2.8.31']
+    3.0.x:
+        time:     2017-11-16 15:14:44
+        versions: ['>=3.0.0', '<3.1.0']
+    3.1.x:
+        time:     2017-11-16 15:14:44
+        versions: ['>=3.1.0', '<3.2.0']
+    3.2.x:
+        time:     2017-11-16 15:17:32
+        versions: ['>=3.2.0', '<3.2.14']
+    3.3.x:
+        time:     2017-11-16 15:24:32
+        versions: ['>=3.3.0', '<3.3.13']
+reference: composer://symfony/security

--- a/symfony/security/CVE-2018-19790.yaml
+++ b/symfony/security/CVE-2018-19790.yaml
@@ -1,0 +1,35 @@
+title:     "CVE-2018-19790: Open Redirect Vulnerability on login"
+link:      https://symfony.com/cve-2018-19790
+cve:       CVE-2018-19790
+branches:
+    2.7.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=2.7.38', '<2.7.50']
+    2.8.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=2.8.0', '<2.8.49']
+    3.0.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=3.0.0', '<3.1.0']
+    3.1.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=3.1.0', '<3.2.0']
+    3.2.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=3.2.0', '<3.3.0']
+    3.3.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=3.3.0', '<3.4.0']
+    3.4.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=3.4.0', '<3.4.19']
+    4.0.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=4.0.0', '<4.0.15']
+    4.1.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=4.1.0', '<4.1.9']
+    4.2.x:
+        time:     2018-11-06 11:52:00
+        versions: ['>=4.2.0', '<4.2.1']
+reference: composer://symfony/security


### PR DESCRIPTION
While reviewing #342 I realised that we missed to include some CVEs associated with some of the Security subcomponents where not included in `symfony/security`.