### PR TITLE
[FEATURE] Add TYPO3-CORE-SA-2018-005 to TYPO3-CORE-SA-2018-012

### DIFF
--- a/typo3/cms-core/2018-12-11-1.yaml
+++ b/typo3/cms-core/2018-12-11-1.yaml
@@ -1,0 +1,10 @@
+title:     Cross-Site Scripting in CKEditor
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-005/
+branches:
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.5.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-12-11-2.yaml
+++ b/typo3/cms-core/2018-12-11-2.yaml
@@ -1,0 +1,10 @@
+title:     Cross-Site Scripting in Online Media Asset Rendering
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-006/
+branches:
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-12-11-3.yaml
+++ b/typo3/cms-core/2018-12-11-3.yaml
@@ -1,0 +1,10 @@
+title:     Cross-Site Scripting in Backend Modal Component
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-007/
+branches:
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.5.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-12-11-4.yaml
+++ b/typo3/cms-core/2018-12-11-4.yaml
@@ -1,0 +1,10 @@
+title:     Cross-Site Scripting in Frontend User Login
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-008/
+branches:
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-12-11-5.yaml
+++ b/typo3/cms-core/2018-12-11-5.yaml
@@ -1,0 +1,10 @@
+title:     Security Misconfiguration in Install Tool Cookie
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-009/
+branches:
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-12-11-6.yaml
+++ b/typo3/cms-core/2018-12-11-6.yaml
@@ -1,0 +1,10 @@
+title:     Information Disclosure in Install Tool
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-010/
+branches:
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-12-11-7.yaml
+++ b/typo3/cms-core/2018-12-11-7.yaml
@@ -1,0 +1,10 @@
+title:     Denial of Service in Online Media Asset Handling
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-011/
+branches:
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms-core

--- a/typo3/cms-core/2018-12-11-8.yaml
+++ b/typo3/cms-core/2018-12-11-8.yaml
@@ -1,0 +1,7 @@
+title:     Denial of Service in Frontend Record Registration
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-012/
+branches:
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+reference: composer://typo3/cms-core

--- a/typo3/cms/2018-12-11-1.yaml
+++ b/typo3/cms/2018-12-11-1.yaml
@@ -1,0 +1,10 @@
+title:     Cross-Site Scripting in CKEditor
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-005/
+branches:
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.5.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-12-11-2.yaml
+++ b/typo3/cms/2018-12-11-2.yaml
@@ -1,0 +1,13 @@
+title:     Cross-Site Scripting in Online Media Asset Rendering
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-006/
+branches:
+    7.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=7.5.0', '<7.6.32']
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-12-11-3.yaml
+++ b/typo3/cms/2018-12-11-3.yaml
@@ -1,0 +1,13 @@
+title:     Cross-Site Scripting in Backend Modal Component
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-007/
+branches:
+    7.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=7.1.0', '<7.6.32']
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.5.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-12-11-4.yaml
+++ b/typo3/cms/2018-12-11-4.yaml
@@ -1,0 +1,13 @@
+title:     Cross-Site Scripting in Frontend User Login
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-008/
+branches:
+    7.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=7.0.0', '<7.6.32']
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-12-11-5.yaml
+++ b/typo3/cms/2018-12-11-5.yaml
@@ -1,0 +1,13 @@
+title:     Security Misconfiguration in Install Tool Cookie
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-009/
+branches:
+    7.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=7.0.0', '<7.6.32']
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-12-11-6.yaml
+++ b/typo3/cms/2018-12-11-6.yaml
@@ -1,0 +1,13 @@
+title:     Information Disclosure in Install Tool
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-010/
+branches:
+    7.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=7.0.0', '<7.6.32']
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-12-11-7.yaml
+++ b/typo3/cms/2018-12-11-7.yaml
@@ -1,0 +1,13 @@
+title:     Denial of Service in Online Media Asset Handling
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-011/
+branches:
+    7.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=7.0.0', '<7.6.32']
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+    9.x:
+        time:     2018-07-12 14:13:00
+        versions: ['>=9.0.0', '<9.5.2']
+reference: composer://typo3/cms

--- a/typo3/cms/2018-12-11-8.yaml
+++ b/typo3/cms/2018-12-11-8.yaml
@@ -1,0 +1,10 @@
+title:     Denial of Service in Frontend Record Registration
+link:      https://typo3.org/security/advisory/typo3-core-sa-2018-012/
+branches:
+    7.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=7.0.0', '<7.6.32']
+    8.x:
+        time:     2018-12-11 14:13:00
+        versions: ['>=8.0.0', '<8.7.21']
+reference: composer://typo3/cms


### PR DESCRIPTION
Add latest TYPO3 CMS Security Advisories

* https://typo3.org/security/advisory/typo3-core-sa-2018-005/
* https://typo3.org/security/advisory/typo3-core-sa-2018-006/
* https://typo3.org/security/advisory/typo3-core-sa-2018-007/
* https://typo3.org/security/advisory/typo3-core-sa-2018-008/
* https://typo3.org/security/advisory/typo3-core-sa-2018-009/
* https://typo3.org/security/advisory/typo3-core-sa-2018-010/
* https://typo3.org/security/advisory/typo3-core-sa-2018-011/
* https://typo3.org/security/advisory/typo3-core-sa-2018-012/

Package "typo3/cms" addresses legacy packages, "typo3/cms-core"
addresses the sub-tree split packages since v8.x, which became
a mandatory package in v9.0.0.