### PR TITLE
Add XSS vulnerability in league/commonmark

### DIFF
--- a/league/commonmark/2018-12-29.yaml
+++ b/league/commonmark/2018-12-29.yaml
@@ -1,0 +1,7 @@
+title:     XSS vulnerability with unsafe link protocols
+link:      https://github.com/thephpleague/commonmark/issues/337
+branches:
+    0.x:
+        time:     2018-12-29 20:39:28
+        versions: ['>=0.15.6', '<0.18.1']
+reference: composer://league/commonmark


### PR DESCRIPTION
[A vulnerability found in league/commonmark 0.15.6 - 0.18.0](https://github.com/thephpleague/commonmark/issues/337) has been fixed in [0.18.1](https://github.com/thephpleague/commonmark/releases/tag/0.18.1).