### PR TITLE
remove optional CVE-key when empty

### DIFF
--- a/3f/pygmentize/2017-05-15.yaml
+++ b/3f/pygmentize/2017-05-15.yaml
@@ -1,6 +1,5 @@
 title: Remote Code Execution
 link: https://github.com/dedalozzo/pygmentize/issues/1
-cve: ~
 branches:
     1.x:
         time: 2017-05-15 09:09:00

--- a/alterphp/easyadmin-extension-bundle/2018-10-02.yaml
+++ b/alterphp/easyadmin-extension-bundle/2018-10-02.yaml
@@ -1,6 +1,5 @@
 title:     Action case insensitivity 
 link:      https://github.com/alterphp/EasyAdminExtensionBundle/releases/tag/v1.3.1
-cve:       ~
 branches:
     1.3.x:
         time:     2018-10-02 00:01:00

--- a/amphp/artax/2017-05-09.yaml
+++ b/amphp/artax/2017-05-09.yaml
@@ -1,6 +1,5 @@
 title:     Cookie leakage to wrong origins and non-restricted cookie acceptance
 link:      https://github.com/amphp/artax/releases/tag/v2.0.6
-cve:       ~
 branches:
     2.x:
         time:     2017-05-09 19:42:02

--- a/amphp/http/2018-03-15.yaml
+++ b/amphp/http/2018-03-15.yaml
@@ -1,6 +1,5 @@
 title:     Incorrect header injection check
 link:      https://github.com/amphp/http/releases/tag/v1.0.1
-cve:       ~
 branches:
     master:
         time:     2018-03-15 17:25:00

--- a/asymmetricrypt/asymmetricrypt/2017-11-20.yaml
+++ b/asymmetricrypt/asymmetricrypt/2017-11-20.yaml
@@ -1,6 +1,5 @@
 title:      Padding Oracle Vulnerability in RSA Encryption
 link:       https://github.com/Cosmicist/AsymmetriCrypt/issues/4
-cve:        ~
 branches:
     0.x:
         time:     ~

--- a/cakephp/cakephp/2014-04-29.yaml
+++ b/cakephp/cakephp/2014-04-29.yaml
@@ -1,6 +1,5 @@
 title:     SecurityComponent cross form submission issue
 link:      https://bakery.cakephp.org/2014/04/29/CakePHP-1-3-18-and-2-4-8-released.html
-cve:       ~
 branches:
     2.0.x:
         time:     2014-04-29 11:30:00

--- a/cakephp/cakephp/2015-05-07.yaml
+++ b/cakephp/cakephp/2015-05-07.yaml
@@ -1,6 +1,5 @@
 title:     Incorrect CSRF validation
 link:      https://bakery.cakephp.org/2015/05/07/cakephp_3_0_4_released.html
-cve:       ~
 branches:
     3.0.x:
         time:     2015-05-07 11:30:00

--- a/cakephp/cakephp/2015-05-28.yaml
+++ b/cakephp/cakephp/2015-05-28.yaml
@@ -1,6 +1,5 @@
 title:     Denial of Service attack through XML payloads
 link:      https://bakery.cakephp.org/2015/05/28/cakephp_2_6_6_and_3_0_6_released.html
-cve:       ~
 branches:
     3.0.x:
         time:     2015-05-28 11:30:00

--- a/cakephp/cakephp/2015-08-06.yaml
+++ b/cakephp/cakephp/2015-08-06.yaml
@@ -1,6 +1,5 @@
 title: Direct access of prefixed controller actions
 link: https://bakery.cakephp.org/2015/08/06/cakephp_2_5_9_2_6_10_2_7_2_released.html
-cve: ~
 branches:
     2.0.x:
         time:     2015-08-06 22:08:00

--- a/cakephp/cakephp/2015-11-05.yaml
+++ b/cakephp/cakephp/2015-11-05.yaml
@@ -1,6 +1,5 @@
 title: Remote File Inclusion through View template name manipulation
 link: https://bakery.cakephp.org/2015/11/05/cakephp_3015_314_2612_276_released.html
-cve: ~
 branches:
     2.0.x:
         time:     2015-11-05 22:08:00

--- a/cakephp/cakephp/2018-05-20.yaml
+++ b/cakephp/cakephp/2018-05-20.yaml
@@ -1,6 +1,5 @@
 title: XSS in some development error pages
 link: https://bakery.cakephp.org/2018/05/20/cakephp_364_3517_3414_released.html
-cve: ~
 branches:
     3.4.x:
         time:     2018-05-20 22:08:00

--- a/cart2quote/module-quotation/2017-02-01.yaml
+++ b/cart2quote/module-quotation/2017-02-01.yaml
@@ -1,6 +1,5 @@
 title:     Remote Code Execution in Qquoteadv/controllers/DownloadController.php
 link:      https://cart2quote.zendesk.com/hc/en-us/articles/115000616303--FIXED-Security-Vulnerability-in-downloadCustomOptionAction
-cve:       ~
 branches:
     4.x:
         time:     2017-02-01 10:45:00

--- a/cartalyst/sentry/2016-09-05.yaml
+++ b/cartalyst/sentry/2016-09-05.yaml
@@ -1,6 +1,5 @@
 title:     Null reset codes were allowed
 link:      https://haxx.ml/post/149975211631/how-i-hacked-your-cfp-and-probably-some-other
-cve:       ~
 branches:
     2.1.x:
         time:     2016-10-04 20:18:00

--- a/codeigniter/framework/2015-10-31-1.yaml
+++ b/codeigniter/framework/2015-10-31-1.yaml
@@ -1,6 +1,5 @@
 title: XSS attack vector in Security Library method xss_clean()
 link: https://www.codeigniter.com/user_guide/changelog.html#version-3-0-3
-cve: ~
 branches:
     master:
         time:     2015-10-27 12:30:18

--- a/codeigniter/framework/2016-07-26-1.yaml
+++ b/codeigniter/framework/2016-07-26-1.yaml
@@ -1,6 +1,5 @@
 title: Critical SQL injection bug in the ODBC database driver
 link: https://forum.codeigniter.com/thread-65803.html
-cve: ~
 branches:
     "3.0":
         time:     2015-07-26 19:42:05

--- a/contao/core/2014-02-13.yaml
+++ b/contao/core/2014-02-13.yaml
@@ -1,6 +1,5 @@
 title:     PHP object injection vulnerability allows for arbitrary code execution
 link:      https://contao.org/en/news/major-security-hole-found-in-contao.html
-cve:       ~
 branches:
     2.x:
         time:     2014-02-13 11:12:34

--- a/contao/core/2014-04-07.yaml
+++ b/contao/core/2014-04-07.yaml
@@ -1,6 +1,5 @@
 title:     Insufficient input validation allows for code injection and remote execution
 link:      https://contao.org/en/news/new-security-hole-found-in-contao.html
-cve:       ~
 branches:
     2.x:
         time:     2014-04-07 10:30:27

--- a/doctrine/dbal/2011-09-25.yaml
+++ b/doctrine/dbal/2011-09-25.yaml
@@ -1,6 +1,5 @@
 title:     SQL injection possibility
 link:      https://www.doctrine-project.org/blog/dbal-security-2011-1.html
-cve:       ~
 branches:
     2.0.x:
         time:     2011-08-29 22:36:11

--- a/doctrine/doctrine-module/2013-05-16.yaml
+++ b/doctrine/doctrine-module/2013-05-16.yaml
@@ -1,6 +1,5 @@
 title:     Authentication Vulnerability - possible attempt to login via zero-valued password credential
 link:      https://github.com/doctrine/DoctrineModule/issues/249
-cve:       ~
 branches:
     master:
         time:     2013-05-16 18:29:36

--- a/doctrine/orm/2011-09-25.yaml
+++ b/doctrine/orm/2011-09-25.yaml
@@ -1,6 +1,5 @@
 title:     SQL injection possibility
 link:      https://www.doctrine-project.org/blog/doctrine-security-fix.html
-cve:       ~
 branches:
     2.x:
         time:     2011-09-25 17:37:08

--- a/firebase/php-jwt/2015-04-02.yaml
+++ b/firebase/php-jwt/2015-04-02.yaml
@@ -1,6 +1,5 @@
 title:     Critical vulnerabilities in JSON Web Token libraries
 link:      https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
-cve:       ~
 branches:
     master:
         time:     2015-04-01 18:08:35

--- a/friendsofsymfony/rest-bundle/2014-01-22-1.yaml
+++ b/friendsofsymfony/rest-bundle/2014-01-22-1.yaml
@@ -1,6 +1,5 @@
 title:     Fixed issue with broken validation of JSONP callbacks
 link:      https://symfony.com/blog/fosrestbundle-security-issue-with-jsonp-handler
-cve:       ~
 branches:
     1.2.x:
         time:     2014-01-22 12:35:42

--- a/friendsofsymfony/user-bundle/2012-07-10-1.yaml
+++ b/friendsofsymfony/user-bundle/2012-07-10-1.yaml
@@ -1,6 +1,5 @@
 title:     Fixed the user refreshing to check the identity by primary key instead of username
 link:      https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Changelog.md
-cve:       ~
 branches:
     1.2.x:
         time:     2012-07-10 12:35:42

--- a/friendsofsymfony/user-bundle/2012-07-10-2.yaml
+++ b/friendsofsymfony/user-bundle/2012-07-10-2.yaml
@@ -1,6 +1,5 @@
 title:     Fixes a security issue where the session could be hijacked
 link:      https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Changelog.md
-cve:       ~
 branches:
     1.2.x:
         time:     2012-07-10 17:28:35

--- a/friendsofsymfony/user-bundle/2014-09-04-1.yaml
+++ b/friendsofsymfony/user-bundle/2014-09-04-1.yaml
@@ -1,6 +1,5 @@
 title:     Entropy is lost in the TokenGenerator
 link:      https://symfony.com/blog/fosuserbundle-entropy-of-generated-tokens-is-lost
-cve:       ~
 branches:
     1.2.x:
         time:     2014-09-04 12:28:43

--- a/fuel/core/2016-06-29-1.yaml
+++ b/fuel/core/2016-06-29-1.yaml
@@ -1,6 +1,5 @@
 title:     ImageMagick driver does not escape all shell arguments.
 link:      https://fuelphp.com/security-advisories
-cve:       ~
 branches:
     master:
         time:     2016-09-27 08:06:00

--- a/fuel/core/2018-04-14-1.yaml
+++ b/fuel/core/2018-04-14-1.yaml
@@ -1,6 +1,5 @@
 title:     Crypt encryption compromised.
 link:      https://fuelphp.com/security-advisories
-cve:       ~
 branches:
     master:
         time:     2018-04-16 17:23:00

--- a/gree/jose/2016-08-30.yaml
+++ b/gree/jose/2016-08-30.yaml
@@ -1,6 +1,5 @@
 title: Critical vulnerabilities in JSON Web Token libraries
 link: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
-cve: ~
 branches:
   master: 
     time: 2016-08-30 10:37:36

--- a/gregwar/rst/2016-10-31.yaml
+++ b/gregwar/rst/2016-10-31.yaml
@@ -1,6 +1,5 @@
 title:     Local File Inclusion Vulnerability
 link:      https://hackerone.com/reports/179034
-cve:       ~
 branches:
     master:
         time: 2016-10-31 09:00:00

--- a/illuminate/auth/2014-04-15.yaml
+++ b/illuminate/auth/2014-04-15.yaml
@@ -1,6 +1,5 @@
 title:     Hijacked authentication cookies vulnerability
 link:      https://laravel.com/docs/5.1/upgrade#upgrade-4.1.26
-cve:       ~
 branches:
     4.0.x:
         time:     2014-04-15 12:19:00

--- a/illuminate/cookie/2018-08-08-1.yaml
+++ b/illuminate/cookie/2018-08-08-1.yaml
@@ -1,6 +1,5 @@
 title:     Cookie serialization vulnerability
 link:      https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30
-cve:       ~
 branches:
     4.0.x:
         time:     ~

--- a/illuminate/database/2014-05-20.yaml
+++ b/illuminate/database/2014-05-20.yaml
@@ -1,6 +1,5 @@
 title:     Risk of mass-assignment vulnerabilities
 link:      https://laravel.com/docs/5.1/upgrade#upgrade-4.1.29
-cve:       ~
 branches:
     4.0.x:
         time:     2014-05-20 10:21:00

--- a/illuminate/encryption/2018-03-30-1.yaml
+++ b/illuminate/encryption/2018-03-30-1.yaml
@@ -1,6 +1,5 @@
 title:     Exploit of encryption failure vulnerability
 link:      https://medium.com/@taylorotwell/laravel-security-release-5-6-15-and-5-5-40-56f1257933a0
-cve:       ~
 branches:
     4.0.x:
         time:     ~

--- a/joomla/session/2015-12-14.yaml
+++ b/joomla/session/2015-12-14.yaml
@@ -1,6 +1,5 @@
 title:     Remote Code Execution Vulnerability
 link:      https://developer.joomla.org/security-centre/637-20151205-session-remote-code-execution-vulnerability.html
-cve:       ~
 branches:
     master:
         time:     2015-12-14 18:22:25

--- a/laravel/framework/2014-04-15.yaml
+++ b/laravel/framework/2014-04-15.yaml
@@ -1,6 +1,5 @@
 title:     Hijacked authentication cookies vulnerability
 link:      https://laravel.com/docs/5.3/upgrade#upgrade-4.1.26
-cve:       ~
 branches:
     4.0.x:
         time:     2014-04-15 12:19:00

--- a/laravel/framework/2014-05-20.yaml
+++ b/laravel/framework/2014-05-20.yaml
@@ -1,6 +1,5 @@
 title:     Risk of mass-assignment vulnerabilities
 link:      https://laravel.com/docs/5.3/upgrade#upgrade-4.1.29
-cve:       ~
 branches:
     4.0.x:
         time:     2014-05-20 10:21:00

--- a/laravel/framework/2018-03-30-1.yaml
+++ b/laravel/framework/2018-03-30-1.yaml
@@ -1,6 +1,5 @@
 title:     Exploit of encryption failure vulnerability
 link:      https://medium.com/@taylorotwell/laravel-security-release-5-6-15-and-5-5-40-56f1257933a0
-cve:       ~
 branches:
     4.0.x:
         time:     ~

--- a/laravel/framework/2018-08-08-1.yaml
+++ b/laravel/framework/2018-08-08-1.yaml
@@ -1,6 +1,5 @@
 title:     Cookie serialization vulnerability
 link:      https://laravel.com/docs/5.6/upgrade#upgrade-5.6.30
-cve:       ~
 branches:
     4.0.x:
         time:     ~

--- a/laravel/socialite/2015-07-23.yaml
+++ b/laravel/socialite/2015-07-23.yaml
@@ -1,6 +1,5 @@
 title:     Insecure state generation
 link:      https://github.com/laravel/socialite/pull/91
-cve:       ~
 branches:
     1.0.x:
         time:     2015-07-23 13:53:00

--- a/laravel/socialite/2015-08-03.yaml
+++ b/laravel/socialite/2015-08-03.yaml
@@ -1,6 +1,5 @@
 title:     State guessing vulnerability
 link:      https://github.com/laravel/socialite/pull/93
-cve:       ~
 branches:
     1.0.x:
         time:     2015-08-03 12:55:00

--- a/magento/magento1ce/2017-02-07.yaml
+++ b/magento/magento1ce/2017-02-07.yaml
@@ -1,6 +1,5 @@
 title:     SUPEE-9652 - Remote Code Execution using mail vulnerability
 link:      https://magento.com/security/patches/supee-9652
-cve:       ~
 branches:
     1.x:
         time:     2017-02-07 00:00:00

--- a/magento/magento1ce/2018-06-29.yaml
+++ b/magento/magento1ce/2018-06-29.yaml
@@ -1,6 +1,5 @@
 title:     SUPEE-10752 - Multiple security enhancements vulnerabilities
 link:      https://magento.com/security/patches/supee-10752
-cve:       ~
 branches:
     1.x:
         time:     2018-06-29 00:00:00

--- a/magento/magento1ce/2018-11-28.yaml
+++ b/magento/magento1ce/2018-11-28.yaml
@@ -1,6 +1,5 @@
 title:     SUPEE-10975 - Security enhancements that help close RCE,XSS,CSRF and other vulnerabilities
 link:      https://magento.com/security/patches/supee-10975
-cve:       ~
 branches:
     1.x:
         time:     2018-11-26 10:00:58

--- a/magento/magento1ee/2017-02-07.yaml
+++ b/magento/magento1ee/2017-02-07.yaml
@@ -1,6 +1,5 @@
 title:     SUPEE-9652 - Remote Code Execution using mail vulnerability
 link:      https://magento.com/security/patches/supee-9652
-cve:       ~
 branches:
     1.x:
         time:     2017-02-07 00:00:00

--- a/magento/magento1ee/2018-11-28.yaml
+++ b/magento/magento1ee/2018-11-28.yaml
@@ -1,6 +1,5 @@
 title:     SUPEE-10975 - Security enhancements that help close RCE,XSS,CSRF and other vulnerabilities
 link:      https://magento.com/security/patches/supee-10975
-cve:       ~
 branches:
     1.x:
         time:     2018-11-26 10:00:58

--- a/magento/product-community-edition/2018-06-27.yaml
+++ b/magento/product-community-edition/2018-06-27.yaml
@@ -1,6 +1,5 @@
 title:     Magento 2.2.5 and 2.1.14 Security update
 link:      https://magento.com/security/patches/magento-2.2.5-and-2.1.14-security-update
-cve:       ~
 branches:
     "2.1":
         time:     2018-06-27 00:00:00

--- a/magento/product-community-edition/2018-09-10.yaml
+++ b/magento/product-community-edition/2018-09-10.yaml
@@ -1,6 +1,5 @@
 title:     Magento 2.2.6 and 2.1.15 Security update
 link:      https://magento.com/security/patches/magento-2.2.6-and-2.1.15-security-update
-cve:       ~
 branches:
     "2.1":
         time:     2018-09-10 00:00:00

--- a/magento/product-community-edition/2018-11-28.yaml
+++ b/magento/product-community-edition/2018-11-28.yaml
@@ -1,6 +1,5 @@
 title:     Magento 2.2.7 and 2.1.16 Security update. Closes RCE,XSS and other vulnerabilities
 link:      https://magento.com/security/patches/magento-2.2.7-and-2.1.16-security-update
-cve:       ~
 branches:
     "2.1":
         time:     2018-11-28 15:41:00

--- a/monolog/monolog/2014-12-29-1.yaml
+++ b/monolog/monolog/2014-12-29-1.yaml
@@ -1,6 +1,5 @@
 title:     Header injection in NativeMailerHandler
 link:      https://github.com/Seldaek/monolog/pull/448#issuecomment-68208704
-cve:       ~
 branches:
     1.x:
         time:     2014-12-29 13:23:35

--- a/namshi/jose/2015-02-19.yaml
+++ b/namshi/jose/2015-02-19.yaml
@@ -1,6 +1,5 @@
 title:     Attackers able to impersonate users
 link:      https://github.com/namshi/jose/commit/009f86d6ced000b806b2f602c0b7393060ebb34e
-cve:       ~
 branches:
     "1.1":
         time:     2015-02-19 10:59:35

--- a/namshi/jose/2015-03-10.yaml
+++ b/namshi/jose/2015-03-10.yaml
@@ -1,6 +1,5 @@
 title:     Critical vulnerabilities in JSON Web Token libraries
 link:      https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
-cve:       ~
 branches:
     master:
         time:     2015-03-10 07:41:53

--- a/onelogin/php-saml/2017-02-28.yaml
+++ b/onelogin/php-saml/2017-02-28.yaml
@@ -1,6 +1,5 @@
 title:     An error during signature verification can be treated as a successful verification.
 link:      https://github.com/onelogin/php-saml/commit/949359f5cad5e1d085c4e5447d9aa8f49a6e82a1
-cve:       ~
 branches:
     "2.x":
         time:     2017-02-28 15:37:00

--- a/oro/crm/2015-07-08.yaml
+++ b/oro/crm/2015-07-08.yaml
@@ -1,6 +1,5 @@
 title:     Forced Redirect to External Website
 link:      https://www.orocrm.com/blog/news/orocrm-security-announcement
-cve:       ~
 branches:
     "1.7":
         time:     2015-07-08 13:51:00

--- a/oro/platform/2015-07-08.yaml
+++ b/oro/platform/2015-07-08.yaml
@@ -1,6 +1,5 @@
 title:     Forced Redirect to External Website
 link:      https://www.orocrm.com/blog/news/orocrm-security-announcement
-cve:       ~
 branches:
     "1.7":
         time:     2015-07-08 13:47:00

--- a/pagarme/pagarme-php/2017-11-20.yaml
+++ b/pagarme/pagarme-php/2017-11-20.yaml
@@ -1,6 +1,5 @@
 title:      Padding Oracle Vulnerability in RSA Encryption
 link:       https://github.com/pagarme/pagarme-php/issues/29
-cve:        ~
 branches:
     2.x:
         time:     ~

--- a/paragonie/random_compat/2016-03-16.yaml
+++ b/paragonie/random_compat/2016-03-16.yaml
@@ -1,6 +1,5 @@
 title:     Uses insecure CSPRNG (openssl_random_pseudo_bytes())
 link:      https://github.com/paragonie/random_compat/issues/96
-cve:       ~
 branches:
     1.x:
         time:     2016-03-16 00:00:00

--- a/phpxmlrpc/extras/2017-10-29.yaml
+++ b/phpxmlrpc/extras/2017-10-29.yaml
@@ -1,6 +1,5 @@
 title:     XSS in class documenting_xmlrpc_server
 link:      https://github.com/gggeek/phpxmlrpc-extras/releases/tag/0.6.1
-cve:       ~
 branches:
     master:
         time:     2017-10-29 12:24:59

--- a/propel/propel/2018-02-14.yaml
+++ b/propel/propel/2018-02-14.yaml
@@ -1,6 +1,5 @@
 title:     SQL injection possible with limit() on MySQL
 link:      https://github.com/propelorm/Propel2/issues/1463
-cve:       ~
 branches:
     "2.0":
         time:     2018-02-19 13:04:00

--- a/propel/propel1/2018-02-14.yaml
+++ b/propel/propel1/2018-02-14.yaml
@@ -1,6 +1,5 @@
 title:     SQL injection possible with limit() on MySQL
 link:      https://github.com/propelorm/Propel/issues/1052
-cve:       ~
 branches:
     "1.0":
         time:     2018-02-16 13:38:00

--- a/pusher/pusher-php-server/2015-05-13.yaml
+++ b/pusher/pusher-php-server/2015-05-13.yaml
@@ -1,6 +1,5 @@
 title:     Exploit in the private channel authentication
 link:      https://blog.pusher.com/update-on-security/
-cve:       ~
 branches:
     master:
         time:     2015-05-13 10:53:19

--- a/sensiolabs/connect/2018-06-08-1.yaml
+++ b/sensiolabs/connect/2018-06-08-1.yaml
@@ -1,6 +1,5 @@
 title:     Missing state parameter in OAuth requests leading to CSRF vulnerability
 link:      https://github.com/sensiolabs/connect/pull/63
-cve:       ~
 branches:
     "master":
         time:     2017-05-30 11:55:16

--- a/silverstripe/cms/SS-2015-003-1.yaml
+++ b/silverstripe/cms/SS-2015-003-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-003: History XSS Vulnerability"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-003/
-cve:       ~
 branches:
     3.1.x:
         time:     2015-02-12 15:55:00

--- a/silverstripe/cms/SS-2015-005-1.yaml
+++ b/silverstripe/cms/SS-2015-005-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-005: VirtualPage XSS"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-005/
-cve:       ~
 branches:
     3.1.x:
         time:     2015-02-12 15:55:00

--- a/silverstripe/cms/SS-2015-008-1.yaml
+++ b/silverstripe/cms/SS-2015-008-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-008: SiteTree Creation Permission Vulnerability"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-008-sitetree-creation-permission-vulnerability/
-cve:       ~
 branches:
     3.0.x:
         time:     2015-03-19 16:54:00

--- a/silverstripe/forum/SS-2015-017-1.yaml
+++ b/silverstripe/forum/SS-2015-017-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-017: Forum Module CSRF Vulnerability"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-017/
-cve:       ~
 branches:
     0.6.x:
         time:     2015-09-14 10:38:00

--- a/silverstripe/framework/SS-2014-015-1.yaml
+++ b/silverstripe/framework/SS-2014-015-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2014-015: IE requests not properly behaving with rewritehashlinks"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2014-015-ie-requests-not-properly-behaving-with-rewritehashlinks/
-cve:       ~
 branches:
     3.0.x:
         time:     2015-03-20 12:10:00

--- a/silverstripe/framework/SS-2014-017-1.yaml
+++ b/silverstripe/framework/SS-2014-017-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2014-017: XML Quadratic Blowup Attack"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2014-017-xml-quadratic-blowup-attack/
-cve:       ~
 branches:
     3.1.x:
         time:     2014-08-12 11:50:00

--- a/silverstripe/framework/SS-2015-004-1.yaml
+++ b/silverstripe/framework/SS-2015-004-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-004: TreeDropdownField and TreeMultiSelectField XSS"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-004/
-cve:       ~
 branches:
     3.1.x:
         time:     2015-02-12 15:55:00

--- a/silverstripe/framework/SS-2015-006-1.yaml
+++ b/silverstripe/framework/SS-2015-006-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-006: XSS In GridField print"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-006/
-cve:       ~
 branches:
     3.1.x:
         time:     2015-02-12 15:55:00

--- a/silverstripe/framework/SS-2015-007-1.yaml
+++ b/silverstripe/framework/SS-2015-007-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-007: XSS In FormAction"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-007/
-cve:       ~
 branches:
     3.1.x:
         time:     2015-02-12 15:55:00

--- a/silverstripe/framework/SS-2015-009-1.yaml
+++ b/silverstripe/framework/SS-2015-009-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-009: XSS In rewritten hash links"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-009-xss-in-rewritten-hash-links/
-cve:       ~
 branches:
     3.0.x:
         time:     2015-03-20 14:57:00

--- a/silverstripe/framework/SS-2015-010-1.yaml
+++ b/silverstripe/framework/SS-2015-010-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-010: XSS in Director::force_redirect()"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-010-xss-in-directorforce-redirect/
-cve:       ~
 branches:
     3.1.x:
         time:     2015-03-20 15:07:00

--- a/silverstripe/framework/SS-2015-011-1.yaml
+++ b/silverstripe/framework/SS-2015-011-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-011: Potential SQL Injection Vulnerability"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-011/
-cve:       ~
 branches:
     3.0.x:
         time:     2015-05-25 10:52:00

--- a/silverstripe/framework/SS-2015-012-1.yaml
+++ b/silverstripe/framework/SS-2015-012-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-012: External redirection risk in Security?ReturnURL"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-012/
-cve:       ~
 branches:
     3.0.x:
         time:     2015-05-25 14:52:00

--- a/silverstripe/framework/SS-2015-013-1.yaml
+++ b/silverstripe/framework/SS-2015-013-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-013: X-Forwarded-Host request hostname injection"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-013/
-cve:       ~
 branches:
     3.1.x:
         time:     2015-05-29 12:53:14 +1200

--- a/silverstripe/framework/SS-2015-014-1.yaml
+++ b/silverstripe/framework/SS-2015-014-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-014: Vulnerability on 'isDev', 'isTest' and 'flush' $_GET validation"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-014/
-cve:       ~
 branches:
     3.0.x:
         time:     2015-05-28 13:05:00

--- a/silverstripe/framework/SS-2015-015-1.yaml
+++ b/silverstripe/framework/SS-2015-015-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-015: XSS in dev/build returnURL Parameter"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-015/
-cve:       ~
 branches:
     3.1.x:
         time:     2015-09-14 09:17:00

--- a/silverstripe/framework/SS-2015-016-1.yaml
+++ b/silverstripe/framework/SS-2015-016-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-016: XSS in install.php"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-016/
-cve:       ~
 branches:
     3.1.x:
         time:     2015-09-14 10:44:00

--- a/silverstripe/framework/SS-2015-026-1.yaml
+++ b/silverstripe/framework/SS-2015-026-1.yaml
@@ -1,6 +1,5 @@
 title:     'SS-2015-026: Form field validation message XSS vulnerability'
 link:      https://www.silverstripe.org/download/security-releases/ss-2015-026/
-cve:       ~
 branches:
     3.0.x:
         time:     2015-11-11 14:31:00

--- a/silverstripe/framework/SS-2015-027-1.yaml
+++ b/silverstripe/framework/SS-2015-027-1.yaml
@@ -1,6 +1,5 @@
 title:     'SS-2015-027: HtmlEditor embed url sanitisation'
 link:      https://www.silverstripe.org/download/security-releases/ss-2015-027/
-cve:       ~
 branches:
     3.0.x:
         time:     2015-11-13 10:30:00

--- a/silverstripe/framework/SS-2015-028-1.yaml
+++ b/silverstripe/framework/SS-2015-028-1.yaml
@@ -1,6 +1,5 @@
 title:     'SS-2015-028: Missing security check on dev/build/defaults'
 link:      https://www.silverstripe.org/download/security-releases/ss-2015-028/
-cve:       ~
 branches:
     3.1.x:
         time:     2016-02-17 17:55:00

--- a/silverstripe/framework/SS-2016-002-1.yaml
+++ b/silverstripe/framework/SS-2016-002-1.yaml
@@ -1,6 +1,5 @@
 title:     'SS-2016-002: CSRF vulnerability in GridFieldAddExistingAutocompleter'
 link:      https://www.silverstripe.org/download/security-releases/ss-2016-002/
-cve:       ~
 branches:
     3.1.x:
         time:     2016-02-17 17:50:00

--- a/silverstripe/framework/SS-2016-003-1.yaml
+++ b/silverstripe/framework/SS-2016-003-1.yaml
@@ -1,6 +1,5 @@
 title:     'SS-2016-003: Hostname, IP and Protocol Spoofing through HTTP Headers'
 link:      https://www.silverstripe.org/download/security-releases/ss-2016-003/
-cve:       ~
 branches:
     3.1.x:
         time:     2016-02-18 11:05:00

--- a/silverstripe/userforms/SS-2015-018-1.yaml
+++ b/silverstripe/userforms/SS-2015-018-1.yaml
@@ -1,6 +1,5 @@
 title:     "SS-2015-018: File upload exposure on UserForms module"
 link:      https://www.silverstripe.org/software/download/security-releases/ss-2015-018/
-cve:       ~
 branches:
     3.0.x:
         time:     2015-08-31 14:32:00

--- a/squizlabs/php_codesniffer/2017-03-01.yaml
+++ b/squizlabs/php_codesniffer/2017-03-01.yaml
@@ -1,6 +1,5 @@
 title:     Arbitrary shell execution
 link:      https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/2.8.1
-cve:       ~
 branches:
     # The 1.x branch is unsupported, mark all versions as vulnerable.
     1.x:

--- a/squizlabs/php_codesniffer/2017-05-18.yaml
+++ b/squizlabs/php_codesniffer/2017-05-18.yaml
@@ -1,6 +1,5 @@
 title:     Arbitrary shell execution
 link:      https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.0.1
-cve:       ~
 branches:
     3.0.x:
         time:     2017-05-18 04:24:49

--- a/stormpath/sdk/2017-11-20.yaml
+++ b/stormpath/sdk/2017-11-20.yaml
@@ -1,6 +1,5 @@
 title:      Insecure Random Number Generator
 link:       https://github.com/stormpath/stormpath-sdk-php/issues/132
-cve:        ~
 branches:
     0.x:
         time:     ~

--- a/swiftmailer/swiftmailer/2014-06-13.yaml
+++ b/swiftmailer/swiftmailer/2014-06-13.yaml
@@ -1,6 +1,5 @@
 title:     Sendmail transport arbitrary shell execution
 link:      http://blog.swiftmailer.org/post/88660759928/security-fix-swiftmailer-5-2-1-released
-cve:       ~
 branches:
     4.x:
         time:     2014-06-13 11:45:24

--- a/sylius/admin-bundle/2018-07-09.yaml
+++ b/sylius/admin-bundle/2018-07-09.yaml
@@ -1,6 +1,5 @@
 title: CSRF vulnerability in the admin panel
 link: https://sylius.com/blog/csrf-vulnerability-in-admin-panel/
-cve: ~
 branches:
     1.0.x:
         time: 2018-07-08 23:47:50

--- a/sylius/sylius/2018-07-09.yaml
+++ b/sylius/sylius/2018-07-09.yaml
@@ -1,6 +1,5 @@
 title: CSRF vulnerability in the admin panel
 link: https://sylius.com/blog/csrf-vulnerability-in-admin-panel/
-cve: ~
 branches:
     1.0.x:
         time: 2018-07-08 23:47:50

--- a/symfony/dependency-injection/2012-08-28.yaml
+++ b/symfony/dependency-injection/2012-08-28.yaml
@@ -1,6 +1,5 @@
 title:     Security fixes related to the way XML is handled
 link:      https://symfony.com/blog/security-release-symfony-2-0-17-released
-cve:       ~
 branches:
     2.0.x:
         time:     2012-08-27 19:17:44

--- a/symfony/http-foundation/2012-11-29.yaml
+++ b/symfony/http-foundation/2012-11-29.yaml
@@ -1,6 +1,5 @@
 title:     Request::getClientIp() when the trust proxy mode is enabled
 link:      https://symfony.com/blog/security-release-symfony-2-0-19-and-2-1-4
-cve:       ~
 branches:
     2.0.x:
         time:     2012-11-27 22:21:23

--- a/symfony/routing/2012-08-28.yaml
+++ b/symfony/routing/2012-08-28.yaml
@@ -1,6 +1,5 @@
 title:     Security fixes related to the way XML is handled
 link:      https://symfony.com/blog/security-release-symfony-2-0-17-released
-cve:       ~
 branches:
     2.0.x:
         time:     2012-08-27 19:17:44

--- a/symfony/serializer/2012-02-24.yaml
+++ b/symfony/serializer/2012-02-24.yaml
@@ -1,6 +1,5 @@
 title:     XML decoding attack vector through external entities
 link:      https://symfony.com/blog/security-release-symfony-2-0-11-released
-cve:       ~
 branches:
     2.0.x:
         time:     2012-02-24 13:26:13

--- a/symfony/symfony/2011-11-16.yaml
+++ b/symfony/symfony/2011-11-16.yaml
@@ -1,6 +1,5 @@
 title:     Vulnerability in the EntityUserProvider as provided in the Doctrine bridge
 link:      https://symfony.com/blog/security-release-symfony-2-0-6
-cve:       ~
 branches:
     2.0.x:
         time:     2012-11-08 08:33:49

--- a/symfony/symfony/2012-02-24.yaml
+++ b/symfony/symfony/2012-02-24.yaml
@@ -1,6 +1,5 @@
 title:     XML decoding attack vector through external entities
 link:      https://symfony.com/blog/security-release-symfony-2-0-11-released
-cve:       ~
 branches:
     2.0.x:
         time:     2012-02-24 13:26:13

--- a/symfony/symfony/2012-08-28.yaml
+++ b/symfony/symfony/2012-08-28.yaml
@@ -1,6 +1,5 @@
 title:     Security fixes related to the way XML is handled
 link:      https://symfony.com/blog/security-release-symfony-2-0-17-released
-cve:       ~
 branches:
     2.0.x:
         time:     2012-08-27 19:17:44

--- a/symfony/symfony/2012-11-29.yaml
+++ b/symfony/symfony/2012-11-29.yaml
@@ -1,6 +1,5 @@
 title:     Request::getClientIp() when the trust proxy mode is enabled
 link:      https://symfony.com/blog/security-release-symfony-2-0-19-and-2-1-4
-cve:       ~
 branches:
     2.0.x:
         time:     2012-11-27 19:09:41

--- a/symfony/translation/2012-08-28.yaml
+++ b/symfony/translation/2012-08-28.yaml
@@ -1,6 +1,5 @@
 title:     Security fixes related to the way XML is handled
 link:      https://symfony.com/blog/security-release-symfony-2-0-17-released
-cve:       ~
 branches:
     2.0.x:
         time:     2012-08-27 19:17:44

--- a/symfony/validator/2012-08-28.yaml
+++ b/symfony/validator/2012-08-28.yaml
@@ -1,6 +1,5 @@
 title:     Security fixes related to the way XML is handled
 link:      https://symfony.com/blog/security-release-symfony-2-0-17-released
-cve:       ~
 branches:
     2.0.x:
         time:     2012-08-27 19:17:44

--- a/thelia/backoffice-default-template/2015-02-24-1.yaml
+++ b/thelia/backoffice-default-template/2015-02-24-1.yaml
@@ -1,6 +1,5 @@
 title:     XSS injection in backoffice
 link:      https://thelia.net/version-2-1-2-with-security-fix
-cve:       ~
 branches:
     2.1.x:
         time:     2015-02-24 17:46:34

--- a/thelia/thelia/2015-02-24-1.yaml
+++ b/thelia/thelia/2015-02-24-1.yaml
@@ -1,6 +1,5 @@
 title:     XSS injection in backoffice
 link:      https://thelia.net/version-2-1-2-with-security-fix
-cve:       ~
 branches:
     2.1.x:
         time:     2015-02-24 17:46:34

--- a/thelia/thelia/2015-04-13-1.yaml
+++ b/thelia/thelia/2015-04-13-1.yaml
@@ -1,6 +1,5 @@
 title:     User authentication bypass
 link:      https://thelia.net/version-2-1-3-with-security-fix
-cve:       ~
 branches:
     2.1.x:
         time:     2015-04-13 12:10:12

--- a/titon/framework/2017-11-20.yaml
+++ b/titon/framework/2017-11-20.yaml
@@ -1,6 +1,5 @@
 title:      Remote Code Execution via Chosen-Ciphertext Attack
 link:       https://github.com/titon/framework/issues/93
-cve:        ~
 branches:
     0.x:
         time:     ~

--- a/twig/twig/2013-04-08.yaml
+++ b/twig/twig/2013-04-08.yaml
@@ -1,6 +1,5 @@
 title:     Vulnerability in the filesystem loader
 link:      http://blog.twig.sensiolabs.org/post/47461911874/security-release-twig-1-12-3-released
-cve:       ~
 branches:
     1.x:
         time:     2013-04-08 13:16:10

--- a/twig/twig/2015-08-12.yaml
+++ b/twig/twig/2015-08-12.yaml
@@ -1,6 +1,5 @@
 title:     Remote code execution in templates
 link:      https://symfony.com/blog/security-release-twig-1-20-0
-cve:       ~
 branches:
     1.x:
         time:     2015-08-12 15:53:50

--- a/typo3/flow/2012-03-28.yaml
+++ b/typo3/flow/2012-03-28.yaml
@@ -1,6 +1,5 @@
 title:     Insecure Unserialize Vulnerability in FLOW3
 link:      https://www.neos.io/news/flow-sa-2012-001.html
-cve:       ~
 branches:
     1.0.x:
         time:     2012-03-28 09:32:37

--- a/typo3/flow/2015-11-23.yaml
+++ b/typo3/flow/2015-11-23.yaml
@@ -1,6 +1,5 @@
 title:     Arbitrary file upload and XML External Entity processing
 link:      https://www.neos.io/news/flow-sa-2015-001.html
-cve:       ~
 branches:
     2.3.x:
         time:     2015-11-23 09:24:00

--- a/typo3/flow/2016-11-01.yaml
+++ b/typo3/flow/2016-11-01.yaml
@@ -1,6 +1,5 @@
 title:     Time-Based Information Disclosure Vulnerability in Flow
 link:      https://www.neos.io/blog/flow-sa-2016-001.html
-cve:       ~
 branches:
     2.3.x:
         time:     2016-11-01 17:00:00

--- a/typo3/neos/2015-03-28.yaml
+++ b/typo3/neos/2015-03-28.yaml
@@ -1,6 +1,5 @@
 title:     Privilege Escalation in TYPO3 Neos
 link:      https://www.neos.io/news/neos-sa-2015-001.html
-cve:       ~
 branches:
     1.1.x:
         time:     2015-03-28 18:26:25

--- a/typo3/neos/2015-11-23.yaml
+++ b/typo3/neos/2015-11-23.yaml
@@ -1,6 +1,5 @@
 title:     XSS vulnerabilities in Neos
 link:      https://www.neos.io/news/neos-sa-2015-002.html
-cve:       ~
 branches:
     1.2.x:
         time:     2015-11-23 21:03:00

--- a/ua-parser/uap-php/2018-12-14.yaml
+++ b/ua-parser/uap-php/2018-12-14.yaml
@@ -1,6 +1,5 @@
 title: Denial of service
 link: https://github.com/ua-parser/uap-core/pull/363
-cve: ~
 branches:
     master:
         time:       '2018-12-14 12:44:10'

--- a/willdurand/js-translation-bundle/2014-07-29-1.yaml
+++ b/willdurand/js-translation-bundle/2014-07-29-1.yaml
@@ -1,6 +1,5 @@
 title:     Fixed potential path traversal attack and remote code injection
 link:      https://github.com/willdurand/BazingaJsTranslationBundle/releases/tag/v2.1.1
-cve:       ~
 branches:
     2.1.x:
         time:     2014-07-29 11:19:06

--- a/zendframework/zend-form/ZF2014-03.yaml
+++ b/zendframework/zend-form/ZF2014-03.yaml
@@ -1,6 +1,5 @@
 title:     Potential XSS vector in multiple view helpers
 link:      https://framework.zend.com/security/advisory/ZF2014-03
-cve: ~
 branches:
     2.2.x:
         time:     2014-02-26 16:02:02

--- a/zendframework/zend-json/ZF2014-01.yaml
+++ b/zendframework/zend-json/ZF2014-01.yaml
@@ -1,6 +1,5 @@
 title:     "Potential XXE/XEE attacks using PHP functions: simplexml_load_*, DOMDocument::loadXML, and xml_parse"
 link:      https://framework.zend.com/security/advisory/ZF2014-01
-cve: ~
 branches:
     2.1.x:
         time:     2014-02-26 16:02:02

--- a/zendframework/zend-navigation/ZF2014-03.yaml
+++ b/zendframework/zend-navigation/ZF2014-03.yaml
@@ -1,6 +1,5 @@
 title:     Potential XSS vector in multiple view helpers
 link:      https://framework.zend.com/security/advisory/ZF2014-03
-cve: ~
 branches:
     2.2.x:
         time:     2014-02-26 16:02:02

--- a/zendframework/zend-session/ZF2015-01.yaml
+++ b/zendframework/zend-session/ZF2015-01.yaml
@@ -1,6 +1,5 @@
 title:     Session validation vulnerability
 link:      https://framework.zend.com/security/advisory/ZF2015-01
-cve:       ~
 branches:
     2.0.x:
         time:     2015-01-14 22:00:00

--- a/zendframework/zend-view/ZF2014-03.yaml
+++ b/zendframework/zend-view/ZF2014-03.yaml
@@ -1,6 +1,5 @@
 title:     Potential XSS vector in multiple view helpers
 link:      https://framework.zend.com/security/advisory/ZF2014-03
-cve: ~
 branches:
     2.2.x:
         time:     2014-02-26 16:02:02

--- a/zendframework/zend-xmlrpc/ZF2014-01.yaml
+++ b/zendframework/zend-xmlrpc/ZF2014-01.yaml
@@ -1,6 +1,5 @@
 title:     "Potential XXE/XEE attacks using PHP functions: simplexml_load_*, DOMDocument::loadXML, and xml_parse"
 link:      https://framework.zend.com/security/advisory/ZF2014-01
-cve: ~
 branches:
     2.1.x:
         time:     2014-02-26 16:02:02

--- a/zendframework/zendframework/ZF2012-03.yaml
+++ b/zendframework/zendframework/ZF2012-03.yaml
@@ -1,6 +1,5 @@
 title:     Potential XSS Vectors in Multiple Zend Framework 2 Components
 link:      https://framework.zend.com/security/advisory/ZF2012-03
-cve: ~
 branches:
     2.0.x:
         time:     2012-09-20 15:22:57

--- a/zendframework/zendframework/ZF2012-04.yaml
+++ b/zendframework/zendframework/ZF2012-04.yaml
@@ -1,6 +1,5 @@
 title:     Potential Proxy Injection Vulnerabilities in Multiple Zend Framework 2 Components
 link:      https://framework.zend.com/security/advisory/ZF2012-04
-cve: ~
 branches:
     2.0.x:
         time:     2012-09-29 16:19:54

--- a/zendframework/zendframework/ZF2013-01.yaml
+++ b/zendframework/zendframework/ZF2013-01.yaml
@@ -1,6 +1,5 @@
 title:     Route Parameter Injection Via Query String in Zend\Mvc
 link:      https://framework.zend.com/security/advisory/ZF2013-01
-cve: ~
 branches:
     2.0.x:
         time:     2013-03-13 08:39:38

--- a/zendframework/zendframework/ZF2013-02.yaml
+++ b/zendframework/zendframework/ZF2013-02.yaml
@@ -1,6 +1,5 @@
 title:     Potential Information Disclosure and Insufficient Entropy vulnerabilities in Zend\Math\Rand and Zend\Validate\Csrf Components
 link:      https://framework.zend.com/security/advisory/ZF2013-02
-cve: ~
 branches:
     2.0.x:
         time:     2013-03-13 15:05:23

--- a/zendframework/zendframework/ZF2013-03.yaml
+++ b/zendframework/zendframework/ZF2013-03.yaml
@@ -1,6 +1,5 @@
 title:     Potential SQL injection due to execution of platform-specific SQL containing interpolations
 link:      https://framework.zend.com/security/advisory/ZF2013-03
-cve: ~
 branches:
     2.0.x:
         time:     2013-03-13 15:04:50

--- a/zendframework/zendframework/ZF2013-04.yaml
+++ b/zendframework/zendframework/ZF2013-04.yaml
@@ -1,6 +1,5 @@
 title:     Potential Remote Address Spoofing Vector in Zend\Http\PhpEnvironment\RemoteAddress
 link:      https://framework.zend.com/security/advisory/ZF2013-04
-cve: ~
 branches:
     2.2.x:
         time:     2013-10-31 10:35:17

--- a/zendframework/zendframework/ZF2014-01.yaml
+++ b/zendframework/zendframework/ZF2014-01.yaml
@@ -1,6 +1,5 @@
 title:     "Potential XXE/XEE attacks using PHP functions: simplexml_load_*, DOMDocument::loadXML, and xml_parse"
 link:      https://framework.zend.com/security/advisory/ZF2014-01
-cve: ~
 branches:
     2.1.x:
         time:     2014-02-26 16:02:02

--- a/zendframework/zendframework/ZF2014-03.yaml
+++ b/zendframework/zendframework/ZF2014-03.yaml
@@ -1,6 +1,5 @@
 title:     Potential XSS vector in multiple view helpers
 link:      https://framework.zend.com/security/advisory/ZF2014-03
-cve: ~
 branches:
     2.2.x:
         time:     2014-02-26 16:02:02

--- a/zendframework/zendframework/ZF2015-01.yaml
+++ b/zendframework/zendframework/ZF2015-01.yaml
@@ -1,6 +1,5 @@
 title:     Session validation vulnerability
 link:      https://framework.zend.com/security/advisory/ZF2015-01
-cve:       ~
 branches:
     2.0.x:
         time:     2015-01-14 22:00:00

--- a/zendframework/zendframework1/ZF2009-01.yaml
+++ b/zendframework/zendframework1/ZF2009-01.yaml
@@ -1,6 +1,5 @@
 title:      LFI vector in Zend_View::setScriptPath() and render()
 link:       https://framework.zend.com/security/advisory/ZF2009-01
-cve:        ~
 branches:
     1.7.x:
         time:     2009-02-13 14:43:21

--- a/zendframework/zendframework1/ZF2009-02.yaml
+++ b/zendframework/zendframework1/ZF2009-02.yaml
@@ -1,6 +1,5 @@
 title:      XSS vector in Zend_Filter_StripTags
 link:       https://framework.zend.com/security/advisory/ZF2009-02
-cve:        ~
 branches:
     1.7.x:
         time:     2009-02-27 09:00:13

--- a/zendframework/zendframework1/ZF2010-01.yaml
+++ b/zendframework/zendframework1/ZF2010-01.yaml
@@ -1,6 +1,5 @@
 title:      Potential XSS vectors due to inconsistent encodings
 link:       https://framework.zend.com/security/advisory/ZF2010-01
-cve:        ~
 branches:
     1.9.x:
         time:     2010-01-08 17:31:22

--- a/zendframework/zendframework1/ZF2010-02.yaml
+++ b/zendframework/zendframework1/ZF2010-02.yaml
@@ -1,6 +1,5 @@
 title:      Potential XSS vector in Zend_Dojo_View_Helper_Editor
 link:       https://framework.zend.com/security/advisory/ZF2010-02
-cve:        ~
 branches:
     1.7.x:
         time:     2010-01-08 17:31:22

--- a/zendframework/zendframework1/ZF2010-03.yaml
+++ b/zendframework/zendframework1/ZF2010-03.yaml
@@ -1,6 +1,5 @@
 title:      Potential XSS vector in Zend_Filter_StripTags when comments allowed
 link:       https://framework.zend.com/security/advisory/ZF2010-03
-cve:        ~
 branches:
     1.7.x:
         time:     2010-01-08 17:31:22

--- a/zendframework/zendframework1/ZF2010-05.yaml
+++ b/zendframework/zendframework1/ZF2010-05.yaml
@@ -1,6 +1,5 @@
 title:     Potential XSS vector in Zend_Service_ReCaptcha_MailHide
 link:      https://framework.zend.com/security/advisory/ZF2010-05
-cve: ~
 branches:
     1.7.x:
         time:     2010-01-08 17:31:22

--- a/zendframework/zendframework1/ZF2010-06.yaml
+++ b/zendframework/zendframework1/ZF2010-06.yaml
@@ -1,6 +1,5 @@
 title:     Potential Security Issues in Bundled Dojo Library
 link:      https://framework.zend.com/security/advisory/ZF2010-06
-cve: ~
 branches:
     1.7.x:
         time:     2010-01-08 17:31:22

--- a/zendframework/zendframework1/ZF2010-07.yaml
+++ b/zendframework/zendframework1/ZF2010-07.yaml
@@ -1,6 +1,5 @@
 title:     Potential Security Issues in Bundled Dojo Library
 link:      https://framework.zend.com/security/advisory/ZF2010-07
-cve: ~
 branches:
     1.9.x:
         time:     2010-04-01 15:22:57

--- a/zendframework/zendframework1/ZF2011-01.yaml
+++ b/zendframework/zendframework1/ZF2011-01.yaml
@@ -1,6 +1,5 @@
 title:     Potential XSS in Development Environment Error View Script
 link:      https://framework.zend.com/security/advisory/ZF2011-01
-cve: ~
 branches:
     1.x:
         time:     2012-06-13 17:24:38

--- a/zendframework/zendframework1/ZF2011-02.yaml
+++ b/zendframework/zendframework1/ZF2011-02.yaml
@@ -1,6 +1,5 @@
 title:     Potential SQL Injection Vector When Using PDO_MySql
 link:      https://framework.zend.com/security/advisory/ZF2011-02
-cve: ~
 branches:
     1.10.x:
         time:     2011-05-03 19:36:13

--- a/zendframework/zendframework1/ZF2012-01.yaml
+++ b/zendframework/zendframework1/ZF2012-01.yaml
@@ -1,6 +1,5 @@
 title:     Local file disclosure via XXE injection in Zend_XmlRpc
 link:      https://framework.zend.com/security/advisory/ZF2012-01
-cve: ~
 branches:
     1.x:
         time:     2012-08-20 17:50:28

--- a/zendframework/zendframework1/ZF2012-02.yaml
+++ b/zendframework/zendframework1/ZF2012-02.yaml
@@ -1,6 +1,5 @@
 title:     Denial of Service vector via XEE injection
 link:      https://framework.zend.com/security/advisory/ZF2012-02
-cve: ~
 branches:
     1.x:
         time:     2012-09-20 15:22:57

--- a/zendframework/zendframework1/ZF2012-05.yaml
+++ b/zendframework/zendframework1/ZF2012-05.yaml
@@ -1,6 +1,5 @@
 title:     Potential XML eXternal Entity injection vectors in Zend Framework 1 Zend_Feed component
 link:      https://framework.zend.com/security/advisory/ZF2012-05
-cve: ~
 branches:
     1.11.x:
         time:     2012-12-18 16:17:16

--- a/zendframework/zendframework1/ZF2014-01.yaml
+++ b/zendframework/zendframework1/ZF2014-01.yaml
@@ -1,6 +1,5 @@
 title:     "Potential XXE/XEE attacks using PHP functions: simplexml_load_*, DOMDocument::loadXML, and xml_parse"
 link:      https://framework.zend.com/security/advisory/ZF2014-01
-cve: ~
 branches:
     1.12.x:
         time:     2014-02-26 16:02:02

--- a/zendframework/zendframework1/ZF2014-02.yaml
+++ b/zendframework/zendframework1/ZF2014-02.yaml
@@ -1,6 +1,5 @@
 title:     Potential security issue in login mechanism of ZendOpenId and Zend_OpenId consumer
 link:      https://framework.zend.com/security/advisory/ZF2014-02
-cve: ~
 branches:
     1.12.x:
         time:     2014-02-17 15:37:54

--- a/zendframework/zendframework1/ZF2014-04.yaml
+++ b/zendframework/zendframework1/ZF2014-04.yaml
@@ -1,6 +1,5 @@
 title:     Potential SQL injection in the ORDER implementation of Zend_Db_Select
 link:      https://framework.zend.com/security/advisory/ZF2014-04
-cve:       ~
 branches:
     1.12.x:
         time:     2014-06-11 13:46:00

--- a/zendframework/zendopenid/ZF2014-02.yaml
+++ b/zendframework/zendopenid/ZF2014-02.yaml
@@ -1,6 +1,5 @@
 title:     Potential security issue in login mechanism of ZendOpenId and Zend_OpenId consumer
 link:      https://framework.zend.com/security/advisory/ZF2014-02
-cve: ~
 branches:
     2.0.x:
         time:     2014-02-17 15:37:54

--- a/zfr/zfr-oauth2-server-module/2014-04-26.yaml
+++ b/zfr/zfr-oauth2-server-module/2014-04-26.yaml
@@ -1,6 +1,5 @@
 title:     Authentication adapter did not verify validity of tokens
 link:      https://github.com/zf-fr/zfr-oauth2-server-module/issues/6
-cve: ~
 branches:
     0.1.x:
         time:     2014-04-26 20:04:29


### PR DESCRIPTION
This pr removes all empty CVE-elements. Since this key is optional, it is superfluous to keep empty elements.