### PR TITLE
Fix date for CVE-2019-6338 and CVE-2019-6339

### DIFF
--- a/drupal/core/CVE-2019-6338.yaml
+++ b/drupal/core/CVE-2019-6338.yaml
@@ -3,7 +3,7 @@ link: https://www.drupal.org/sa-core-2019-001
 cve: CVE-2019-6338
 branches:
   7.x:
-    time:     2018-01-15 17:42:00
+    time:     2019-01-15 17:42:00
     versions: ['>=7.0.0','<7.62.0']
   8.0.x:
     time:     ~
@@ -21,9 +21,9 @@ branches:
     time:     ~
     versions: ['>=8.4.0','<8.5.0']
   8.5.x:
-    time:     2018-01-15 17:41:00
+    time:     2019-01-15 17:41:00
     versions: ['>=8.5.0','<8.5.9']
   8.6.x:
-    time:     2018-01-15 17:41:00
+    time:     2019-01-15 17:41:00
     versions: ['>=8.6.0','<8.6.6']
 reference: composer://drupal/core

--- a/drupal/core/CVE-2019-6339.yaml
+++ b/drupal/core/CVE-2019-6339.yaml
@@ -3,7 +3,7 @@ link: https://www.drupal.org/sa-core-2019-002
 cve: CVE-2019-6339
 branches:
   7.x:
-    time:     2018-01-15 17:42:00
+    time:     2019-01-15 17:42:00
     versions: ['>=7.0.0','<7.62.0']
   8.0.x:
     time:     ~
@@ -21,9 +21,9 @@ branches:
     time:     ~
     versions: ['>=8.4.0','<8.5.0']
   8.5.x:
-    time:     2018-01-15 17:41:00
+    time:     2019-01-15 17:41:00
     versions: ['>=8.5.0','<8.5.9']
   8.6.x:
-    time:     2018-01-15 17:41:00
+    time:     2019-01-15 17:41:00
     versions: ['>=8.6.0','<8.6.6']
 reference: composer://drupal/core

--- a/drupal/drupal/CVE-2019-6338.yaml
+++ b/drupal/drupal/CVE-2019-6338.yaml
@@ -3,7 +3,7 @@ link: https://www.drupal.org/sa-core-2019-001
 cve: CVE-2019-6338
 branches:
   7.x:
-    time:     2018-01-15 17:42:00
+    time:     2019-01-15 17:42:00
     versions: ['>=7.0.0','<7.62.0']
   8.0.x:
     time:     ~
@@ -21,9 +21,9 @@ branches:
     time:     ~
     versions: ['>=8.4.0','<8.5.0']
   8.5.x:
-    time:     2018-01-15 17:41:00
+    time:     2019-01-15 17:41:00
     versions: ['>=8.5.0','<8.5.9']
   8.6.x:
-    time:     2018-01-15 17:41:00
+    time:     2019-01-15 17:41:00
     versions: ['>=8.6.0','<8.6.6']
 reference: composer://drupal/drupal

--- a/drupal/drupal/CVE-2019-6339.yaml
+++ b/drupal/drupal/CVE-2019-6339.yaml
@@ -3,7 +3,7 @@ link: https://www.drupal.org/sa-core-2019-002
 cve: CVE-2019-6339
 branches:
   7.x:
-    time:     2018-01-15 17:42:00
+    time:     2019-01-15 17:42:00
     versions: ['>=7.0.0','<7.62.0']
   8.0.x:
     time:     ~
@@ -21,9 +21,9 @@ branches:
     time:     ~
     versions: ['>=8.4.0','<8.5.0']
   8.5.x:
-    time:     2018-01-15 17:41:00
+    time:     2019-01-15 17:41:00
     versions: ['>=8.5.0','<8.5.9']
   8.6.x:
-    time:     2018-01-15 17:41:00
+    time:     2019-01-15 17:41:00
     versions: ['>=8.6.0','<8.6.6']
 reference: composer://drupal/drupal


### PR DESCRIPTION
Just noticed that the year was wrong on the last Drupal CVE files. Probably does not matter that much, and very quick to do so, right after new years :)

Anyway, here is a PR fixing that up.