### PR TITLE
Add initial dump of drupal contrib SA

### DIFF
--- a/drupal/acquia_connector/sa-contrib-2019-014.yaml
+++ b/drupal/acquia_connector/sa-contrib-2019-014.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-014'
 title: 'Acquia Connector - Moderately critical - Access bypass - SA-CONTRIB-2019-014'
 branches:
-    1.16.x: { time: '2019-02-06 16:38:32', versions: ['>=1.0.0', '<1.16.0'] }
+    1.16.x:
+        time: '2019-02-06 17:13:22'
+        versions: ['>=1.0.0', '<1.16.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/acquia_connector'

--- a/drupal/acquia_connector/sa-contrib-2019-014.yaml
+++ b/drupal/acquia_connector/sa-contrib-2019-014.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-014'
+title: 'Acquia Connector - Moderately critical - Access bypass - SA-CONTRIB-2019-014'
+branches:
+    1.16.x: { time: '2019-02-06 16:38:32', versions: ['>=1.0.0', '<1.16.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/acquia_connector'

--- a/drupal/autologout/sa-contrib-2017-081.yaml
+++ b/drupal/autologout/sa-contrib-2017-081.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-081'
+title: 'Automated Logout - Moderately critical - Cross Site Scripting - SA-CONTRIB-2017-081'
+branches:
+    4.5.x: { time: '2017-11-01 16:38:31', versions: ['>=4.0.0', '<4.5.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/autologout'

--- a/drupal/autologout/sa-contrib-2017-081.yaml
+++ b/drupal/autologout/sa-contrib-2017-081.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-081'
 title: 'Automated Logout - Moderately critical - Cross Site Scripting - SA-CONTRIB-2017-081'
 branches:
-    4.5.x: { time: '2017-11-01 16:38:31', versions: ['>=4.0.0', '<4.5.0'] }
+    4.5.x:
+        time: '2017-11-01 17:13:20'
+        versions: ['>=4.0.0', '<4.5.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/autologout'

--- a/drupal/backup_migrate/sa-contrib-2018-004.yaml
+++ b/drupal/backup_migrate/sa-contrib-2018-004.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-004'
+title: 'Backup and Migrate - Critical - Arbitrary PHP code execution - SA-CONTRIB-2018-004'
+branches:
+    3.4.x: { time: '2018-01-24 16:38:31', versions: ['>=3.0.0', '<3.4.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/backup_migrate'

--- a/drupal/backup_migrate/sa-contrib-2018-004.yaml
+++ b/drupal/backup_migrate/sa-contrib-2018-004.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-004'
 title: 'Backup and Migrate - Critical - Arbitrary PHP code execution - SA-CONTRIB-2018-004'
 branches:
-    3.4.x: { time: '2018-01-24 16:38:31', versions: ['>=3.0.0', '<3.4.0'] }
+    3.4.x:
+        time: '2018-01-24 17:13:21'
+        versions: ['>=3.0.0', '<3.4.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/backup_migrate'

--- a/drupal/bealestreet/sa-contrib-2018-048.yaml
+++ b/drupal/bealestreet/sa-contrib-2018-048.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-048'
 title: 'Beale Street - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-048'
 branches:
-    1.2.x: { time: '2018-07-11 16:38:32', versions: ['>=1.0.0', '<1.2.0'] }
+    1.2.x:
+        time: '2018-07-11 17:13:21'
+        versions: ['>=1.0.0', '<1.2.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/bealestreet'

--- a/drupal/bealestreet/sa-contrib-2018-048.yaml
+++ b/drupal/bealestreet/sa-contrib-2018-048.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-048'
+title: 'Beale Street - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-048'
+branches:
+    1.2.x: { time: '2018-07-11 16:38:32', versions: ['>=1.0.0', '<1.2.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/bealestreet'

--- a/drupal/bible/sa-contrib-2018-003.yaml
+++ b/drupal/bible/sa-contrib-2018-003.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-003'
 title: 'Bible - Critical - Multiple Vulnerabilities  - SA-CONTRIB-2018-003'
 branches:
-    1.7.x: { time: '2018-01-17 16:38:31', versions: ['>=1.0.0', '<1.7.0'] }
+    1.7.x:
+        time: '2018-01-17 17:13:21'
+        versions: ['>=1.0.0', '<1.7.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/bible'

--- a/drupal/bible/sa-contrib-2018-003.yaml
+++ b/drupal/bible/sa-contrib-2018-003.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-003'
+title: 'Bible - Critical - Multiple Vulnerabilities  - SA-CONTRIB-2018-003'
+branches:
+    1.7.x: { time: '2018-01-17 16:38:31', versions: ['>=1.0.0', '<1.7.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/bible'

--- a/drupal/bing_autosuggest_api/sa-contrib-2018-058.yaml
+++ b/drupal/bing_autosuggest_api/sa-contrib-2018-058.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-058'
 title: 'Bing Autosuggest API - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-058'
 branches:
-    1.1.x: { time: '2018-08-29 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-08-29 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/bing_autosuggest_api'

--- a/drupal/bing_autosuggest_api/sa-contrib-2018-058.yaml
+++ b/drupal/bing_autosuggest_api/sa-contrib-2018-058.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-058'
+title: 'Bing Autosuggest API - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-058'
+branches:
+    1.1.x: { time: '2018-08-29 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/bing_autosuggest_api'

--- a/drupal/bootstrap/sa-contrib-2018-074.yaml
+++ b/drupal/bootstrap/sa-contrib-2018-074.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-074'
 title: 'Bootstrap - Moderately critical - Cross site scripting - SA-CONTRIB-2018-074'
 branches:
-    3.14.x: { time: '2018-11-28 16:38:32', versions: ['>=3.0.0', '<3.14.0'] }
+    3.14.x:
+        time: '2018-11-28 17:13:21'
+        versions: ['>=3.0.0', '<3.14.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/bootstrap'

--- a/drupal/bootstrap/sa-contrib-2018-074.yaml
+++ b/drupal/bootstrap/sa-contrib-2018-074.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-074'
+title: 'Bootstrap - Moderately critical - Cross site scripting - SA-CONTRIB-2018-074'
+branches:
+    3.14.x: { time: '2018-11-28 16:38:32', versions: ['>=3.0.0', '<3.14.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/bootstrap'

--- a/drupal/brilliant_gallery/sa-contrib-2017-079.yaml
+++ b/drupal/brilliant_gallery/sa-contrib-2017-079.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-079'
 title: 'Brilliant Gallery - Highly critical - Multiple Vulnerabilities  - SA-CONTRIB-2017-079'
 branches:
-    1.10.x: { time: '2017-10-25 16:38:31', versions: ['>=1.0.0', '<1.10.0'] }
+    1.10.x:
+        time: '2017-10-25 17:13:20'
+        versions: ['>=1.0.0', '<1.10.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/brilliant_gallery'

--- a/drupal/brilliant_gallery/sa-contrib-2017-079.yaml
+++ b/drupal/brilliant_gallery/sa-contrib-2017-079.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-079'
+title: 'Brilliant Gallery - Highly critical - Multiple Vulnerabilities  - SA-CONTRIB-2017-079'
+branches:
+    1.10.x: { time: '2017-10-25 16:38:31', versions: ['>=1.0.0', '<1.10.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/brilliant_gallery'

--- a/drupal/ckeditor_uploadimage/sa-contrib-2018-014.yaml
+++ b/drupal/ckeditor_uploadimage/sa-contrib-2018-014.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-014'
+title: 'CKEditor Upload Image - Critical - Access bypass - SA-CONTRIB-2018-014'
+branches:
+    1.5.x: { time: '2018-02-21 16:38:31', versions: ['>=1.0.0', '<1.5.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/ckeditor_uploadimage'

--- a/drupal/ckeditor_uploadimage/sa-contrib-2018-014.yaml
+++ b/drupal/ckeditor_uploadimage/sa-contrib-2018-014.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-014'
 title: 'CKEditor Upload Image - Critical - Access bypass - SA-CONTRIB-2018-014'
 branches:
-    1.5.x: { time: '2018-02-21 16:38:31', versions: ['>=1.0.0', '<1.5.0'] }
+    1.5.x:
+        time: '2018-02-21 17:13:21'
+        versions: ['>=1.0.0', '<1.5.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/ckeditor_uploadimage'

--- a/drupal/cleantalk/sa-contrib-2019-010.yaml
+++ b/drupal/cleantalk/sa-contrib-2019-010.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-010'
+title: 'Anti Spam by CleanTalk - Critical - Cross site scripting and SQL Injection - SA-CONTRIB-2019-010'
+branches:
+    2.7.x: { time: '2019-01-23 16:38:32', versions: ['>=2.0.0', '<2.7.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/cleantalk'

--- a/drupal/cleantalk/sa-contrib-2019-010.yaml
+++ b/drupal/cleantalk/sa-contrib-2019-010.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-010'
 title: 'Anti Spam by CleanTalk - Critical - Cross site scripting and SQL Injection - SA-CONTRIB-2019-010'
 branches:
-    2.7.x: { time: '2019-01-23 16:38:32', versions: ['>=2.0.0', '<2.7.0'] }
+    2.7.x:
+        time: '2019-01-23 17:13:22'
+        versions: ['>=2.0.0', '<2.7.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/cleantalk'

--- a/drupal/cloud/sa-contrib-2017-086.yaml
+++ b/drupal/cloud/sa-contrib-2017-086.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-086'
+title: 'Cloud - Critical - CSRF - SA-CONTRIB-2017-086'
+branches:
+    1.7.x: { time: '2017-11-29 16:38:31', versions: ['>=1.0.0', '<1.7.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/cloud'

--- a/drupal/cloud/sa-contrib-2017-086.yaml
+++ b/drupal/cloud/sa-contrib-2017-086.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-086'
 title: 'Cloud - Critical - CSRF - SA-CONTRIB-2017-086'
 branches:
-    1.7.x: { time: '2017-11-29 16:38:31', versions: ['>=1.0.0', '<1.7.0'] }
+    1.7.x:
+        time: '2017-11-29 17:13:21'
+        versions: ['>=1.0.0', '<1.7.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/cloud'

--- a/drupal/commerce/sa-contrib-2018-057.yaml
+++ b/drupal/commerce/sa-contrib-2018-057.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-057'
+title: 'Drupal Commerce - Moderately critical - Access bypass - SA-CONTRIB-2018-057'
+branches:
+    2.9.x: { time: '2018-08-29 16:38:32', versions: ['>=2.0.0', '<2.9.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/commerce'

--- a/drupal/commerce/sa-contrib-2018-057.yaml
+++ b/drupal/commerce/sa-contrib-2018-057.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-057'
 title: 'Drupal Commerce - Moderately critical - Access bypass - SA-CONTRIB-2018-057'
 branches:
-    2.9.x: { time: '2018-08-29 16:38:32', versions: ['>=2.0.0', '<2.9.0'] }
+    2.9.x:
+        time: '2018-08-29 17:13:21'
+        versions: ['>=2.0.0', '<2.9.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/commerce'

--- a/drupal/commerce_custom_order_status/sa-contrib-2018-046.yaml
+++ b/drupal/commerce_custom_order_status/sa-contrib-2018-046.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-046'
+title: 'Commerce Custom Order Status - Moderately critical -  Cross Site Scripting - SA-CONTRIB-2018-046'
+branches:
+    1.1.x: { time: '2018-07-11 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/commerce_custom_order_status'

--- a/drupal/commerce_custom_order_status/sa-contrib-2018-046.yaml
+++ b/drupal/commerce_custom_order_status/sa-contrib-2018-046.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-046'
 title: 'Commerce Custom Order Status - Moderately critical -  Cross Site Scripting - SA-CONTRIB-2018-046'
 branches:
-    1.1.x: { time: '2018-07-11 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-07-11 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/commerce_custom_order_status'

--- a/drupal/commerce_klarna_checkout/sa-contrib-2018-062.yaml
+++ b/drupal/commerce_klarna_checkout/sa-contrib-2018-062.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-062'
 title: 'Commerce Klarna Checkout - Moderately critical - Access bypass - SA-CONTRIB-2018-062'
 branches:
-    1.5.x: { time: '2018-09-26 16:38:32', versions: ['>=1.0.0', '<1.5.0'] }
+    1.5.x:
+        time: '2018-09-26 17:13:21'
+        versions: ['>=1.0.0', '<1.5.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/commerce_klarna_checkout'

--- a/drupal/commerce_klarna_checkout/sa-contrib-2018-062.yaml
+++ b/drupal/commerce_klarna_checkout/sa-contrib-2018-062.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-062'
+title: 'Commerce Klarna Checkout - Moderately critical - Access bypass - SA-CONTRIB-2018-062'
+branches:
+    1.5.x: { time: '2018-09-26 16:38:32', versions: ['>=1.0.0', '<1.5.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/commerce_klarna_checkout'

--- a/drupal/config_perms/sa-contrib-2017-083.yaml
+++ b/drupal/config_perms/sa-contrib-2017-083.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-083'
+title: 'Custom Permissions - Moderately critical - Access bypass - SA-CONTRIB-2017-083'
+branches:
+    1.1.x: { time: '2017-11-08 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/config_perms'

--- a/drupal/config_perms/sa-contrib-2017-083.yaml
+++ b/drupal/config_perms/sa-contrib-2017-083.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-083'
 title: 'Custom Permissions - Moderately critical - Access bypass - SA-CONTRIB-2017-083'
 branches:
-    1.1.x: { time: '2017-11-08 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2017-11-08 17:13:20'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/config_perms'

--- a/drupal/config_perms/sa-contrib-2018-010.yaml
+++ b/drupal/config_perms/sa-contrib-2018-010.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-010'
 title: 'Custom Permissions - Moderately critical - Access bypass - SA-CONTRIB-2018-010'
 branches:
-    2.2.x: { time: '2018-02-14 16:38:31', versions: ['>=2.0.0', '<2.2.0'] }
+    2.2.x:
+        time: '2018-02-14 17:13:21'
+        versions: ['>=2.0.0', '<2.2.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/config_perms'

--- a/drupal/config_perms/sa-contrib-2018-010.yaml
+++ b/drupal/config_perms/sa-contrib-2018-010.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-010'
+title: 'Custom Permissions - Moderately critical - Access bypass - SA-CONTRIB-2018-010'
+branches:
+    2.2.x: { time: '2018-02-14 16:38:31', versions: ['>=2.0.0', '<2.2.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/config_perms'

--- a/drupal/config_update/sa-contrib-2017-091.yaml
+++ b/drupal/config_update/sa-contrib-2017-091.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-091'
+title: 'Configuration Update Manager - Moderately critical - Cross Site Request Forgery (CSRF) - SA-CONTRIB-2017-091'
+branches:
+    1.5.x: { time: '2017-12-06 16:38:31', versions: ['>=1.0.0', '<1.5.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/config_update'

--- a/drupal/config_update/sa-contrib-2017-091.yaml
+++ b/drupal/config_update/sa-contrib-2017-091.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-091'
 title: 'Configuration Update Manager - Moderately critical - Cross Site Request Forgery (CSRF) - SA-CONTRIB-2017-091'
 branches:
-    1.5.x: { time: '2017-12-06 16:38:31', versions: ['>=1.0.0', '<1.5.0'] }
+    1.5.x:
+        time: '2017-12-06 17:13:21'
+        versions: ['>=1.0.0', '<1.5.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/config_update'

--- a/drupal/datereminder/sa-contrib-2018-076.yaml
+++ b/drupal/datereminder/sa-contrib-2018-076.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-076'
+title: 'Date Reminder - Moderately critical - Access bypass - SA-CONTRIB-2018-076'
+branches:
+    1.15.x: { time: '2018-11-28 16:38:32', versions: ['>=1.0.0', '<1.15.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/datereminder'

--- a/drupal/datereminder/sa-contrib-2018-076.yaml
+++ b/drupal/datereminder/sa-contrib-2018-076.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-076'
 title: 'Date Reminder - Moderately critical - Access bypass - SA-CONTRIB-2018-076'
 branches:
-    1.15.x: { time: '2018-11-28 16:38:32', versions: ['>=1.0.0', '<1.15.0'] }
+    1.15.x:
+        time: '2018-11-28 17:13:21'
+        versions: ['>=1.0.0', '<1.15.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/datereminder'

--- a/drupal/decoupled_router/sa-contrib-2018-071.yaml
+++ b/drupal/decoupled_router/sa-contrib-2018-071.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-071'
+title: 'Decoupled Router - Critical - Access bypass - SA-CONTRIB-2018-071'
+branches:
+    1.2.x: { time: '2018-10-31 16:38:32', versions: ['>=1.0.0', '<1.2.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/decoupled_router'

--- a/drupal/decoupled_router/sa-contrib-2018-071.yaml
+++ b/drupal/decoupled_router/sa-contrib-2018-071.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-071'
 title: 'Decoupled Router - Critical - Access bypass - SA-CONTRIB-2018-071'
 branches:
-    1.2.x: { time: '2018-10-31 16:38:32', versions: ['>=1.0.0', '<1.2.0'] }
+    1.2.x:
+        time: '2018-10-31 17:13:21'
+        versions: ['>=1.0.0', '<1.2.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/decoupled_router'

--- a/drupal/domain_integration/sa-contrib-2017-084.yaml
+++ b/drupal/domain_integration/sa-contrib-2017-084.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-084'
+title: 'Domain Integration - Moderately critical - Access bypass - SA-CONTRIB-2017-084'
+branches:
+    1.2.x: { time: '2017-11-29 16:38:31', versions: ['>=1.0.0', '<1.2.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/domain_integration'

--- a/drupal/domain_integration/sa-contrib-2017-084.yaml
+++ b/drupal/domain_integration/sa-contrib-2017-084.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-084'
 title: 'Domain Integration - Moderately critical - Access bypass - SA-CONTRIB-2017-084'
 branches:
-    1.2.x: { time: '2017-11-29 16:38:31', versions: ['>=1.0.0', '<1.2.0'] }
+    1.2.x:
+        time: '2017-11-29 17:13:20'
+        versions: ['>=1.0.0', '<1.2.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/domain_integration'

--- a/drupal/entity/sa-contrib-2018-013.yaml
+++ b/drupal/entity/sa-contrib-2018-013.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-013'
 title: 'Entity API - Moderately critical - Information Disclosure - SA-CONTRIB-2018-013'
 branches:
-    1.9.x: { time: '2018-02-14 16:38:31', versions: ['>=1.0.0', '<1.9.0'] }
+    1.9.x:
+        time: '2018-02-14 17:13:21'
+        versions: ['>=1.0.0', '<1.9.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/entity'

--- a/drupal/entity/sa-contrib-2018-013.yaml
+++ b/drupal/entity/sa-contrib-2018-013.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-013'
+title: 'Entity API - Moderately critical - Information Disclosure - SA-CONTRIB-2018-013'
+branches:
+    1.9.x: { time: '2018-02-14 16:38:31', versions: ['>=1.0.0', '<1.9.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/entity'

--- a/drupal/entity_ref_tab_formatter/sa-contrib-2018-008.yaml
+++ b/drupal/entity_ref_tab_formatter/sa-contrib-2018-008.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-008'
+title: 'Entity Reference Tab / Accordion Formatter - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-008'
+branches:
+    1.3.x: { time: '2018-02-07 16:38:31', versions: ['>=1.0.0', '<1.3.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/entity_ref_tab_formatter'

--- a/drupal/entity_ref_tab_formatter/sa-contrib-2018-008.yaml
+++ b/drupal/entity_ref_tab_formatter/sa-contrib-2018-008.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-008'
 title: 'Entity Reference Tab / Accordion Formatter - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-008'
 branches:
-    1.3.x: { time: '2018-02-07 16:38:31', versions: ['>=1.0.0', '<1.3.0'] }
+    1.3.x:
+        time: '2018-02-07 17:13:21'
+        versions: ['>=1.0.0', '<1.3.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/entity_ref_tab_formatter'

--- a/drupal/entityqueue_taxonomy/sa-contrib-2018-052.yaml
+++ b/drupal/entityqueue_taxonomy/sa-contrib-2018-052.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-052'
+title: 'Taxonomy Entity Queue - Critical - SQL Injection - SA-CONTRIB-2018-052'
+branches:
+    1.1.x: { time: '2018-07-18 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/entityqueue_taxonomy'

--- a/drupal/entityqueue_taxonomy/sa-contrib-2018-052.yaml
+++ b/drupal/entityqueue_taxonomy/sa-contrib-2018-052.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-052'
 title: 'Taxonomy Entity Queue - Critical - SQL Injection - SA-CONTRIB-2018-052'
 branches:
-    1.1.x: { time: '2018-07-18 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-07-18 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/entityqueue_taxonomy'

--- a/drupal/esign/sa-contrib-2018-080.yaml
+++ b/drupal/esign/sa-contrib-2018-080.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-080'
+title: 'E-Sign - Moderately critical - Cross site scripting - SA-CONTRIB-2018-080'
+branches:
+    1.10.x: { time: '2018-12-19 16:38:32', versions: ['>=1.0.0', '<1.10.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/esign'

--- a/drupal/esign/sa-contrib-2018-080.yaml
+++ b/drupal/esign/sa-contrib-2018-080.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-080'
 title: 'E-Sign - Moderately critical - Cross site scripting - SA-CONTRIB-2018-080'
 branches:
-    1.10.x: { time: '2018-12-19 16:38:32', versions: ['>=1.0.0', '<1.10.0'] }
+    1.10.x:
+        time: '2018-12-19 17:13:22'
+        versions: ['>=1.0.0', '<1.10.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/esign'

--- a/drupal/eu_cookie_compliance/sa-contrib-2018-047.yaml
+++ b/drupal/eu_cookie_compliance/sa-contrib-2018-047.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-047'
 title: 'EU Cookie Compliance - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-047'
 branches:
-    1.1.x: { time: '2018-07-11 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-07-11 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/eu_cookie_compliance'

--- a/drupal/eu_cookie_compliance/sa-contrib-2018-047.yaml
+++ b/drupal/eu_cookie_compliance/sa-contrib-2018-047.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-047'
+title: 'EU Cookie Compliance - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-047'
+branches:
+    1.1.x: { time: '2018-07-11 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/eu_cookie_compliance'

--- a/drupal/exif/sa-contrib-2018-017.yaml
+++ b/drupal/exif/sa-contrib-2018-017.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-017'
 title: 'Exif - Critical - Access bypass - SA-CONTRIB-2018-017'
 branches:
-    1.1.x: { time: '2018-03-21 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-03-21 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/exif'

--- a/drupal/exif/sa-contrib-2018-017.yaml
+++ b/drupal/exif/sa-contrib-2018-017.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-017'
+title: 'Exif - Critical - Access bypass - SA-CONTRIB-2018-017'
+branches:
+    1.1.x: { time: '2018-03-21 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/exif'

--- a/drupal/feedback_collect/sa-contrib-2017-090.yaml
+++ b/drupal/feedback_collect/sa-contrib-2017-090.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-090'
 title: 'Feedback Collect - Moderately critical - Cross Site Scripting (XSS) - SA-CONTRIB-2017-090'
 branches:
-    1.6.x: { time: '2017-12-06 16:38:31', versions: ['>=1.0.0', '<1.6.0'] }
+    1.6.x:
+        time: '2017-12-06 17:13:21'
+        versions: ['>=1.0.0', '<1.6.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/feedback_collect'

--- a/drupal/feedback_collect/sa-contrib-2017-090.yaml
+++ b/drupal/feedback_collect/sa-contrib-2017-090.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-090'
+title: 'Feedback Collect - Moderately critical - Cross Site Scripting (XSS) - SA-CONTRIB-2017-090'
+branches:
+    1.6.x: { time: '2017-12-06 16:38:31', versions: ['>=1.0.0', '<1.6.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/feedback_collect'

--- a/drupal/filefield_paths/sa-contrib-2018-056.yaml
+++ b/drupal/filefield_paths/sa-contrib-2018-056.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-056'
 title: 'File (Field) Paths - Critical - Remote Code Execution - SA-CONTRIB-2018-056'
 branches:
-    1.1.x: { time: '2018-08-15 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-08-15 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/filefield_paths'

--- a/drupal/filefield_paths/sa-contrib-2018-056.yaml
+++ b/drupal/filefield_paths/sa-contrib-2018-056.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-056'
+title: 'File (Field) Paths - Critical - Remote Code Execution - SA-CONTRIB-2018-056'
+branches:
+    1.1.x: { time: '2018-08-15 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/filefield_paths'

--- a/drupal/filefield_sources/sa-contrib-2018-007.yaml
+++ b/drupal/filefield_sources/sa-contrib-2018-007.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-007'
 title: 'FileField Sources - Moderately critical - Access Bypass - SA-CONTRIB-2018-007'
 branches:
-    1.11.x: { time: '2018-02-07 16:38:31', versions: ['>=1.0.0', '<1.11.0'] }
+    1.11.x:
+        time: '2018-02-07 17:13:21'
+        versions: ['>=1.0.0', '<1.11.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/filefield_sources'

--- a/drupal/filefield_sources/sa-contrib-2018-007.yaml
+++ b/drupal/filefield_sources/sa-contrib-2018-007.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-007'
+title: 'FileField Sources - Moderately critical - Access Bypass - SA-CONTRIB-2018-007'
+branches:
+    1.11.x: { time: '2018-02-07 16:38:31', versions: ['>=1.0.0', '<1.11.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/filefield_sources'

--- a/drupal/focal_point/sa-contrib-2019-015.yaml
+++ b/drupal/focal_point/sa-contrib-2019-015.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-015'
 title: 'Focal Point - Moderately critical - Cross site scripting - SA-CONTRIB-2019-015'
 branches:
-    1.2.x: { time: '2019-02-13 16:38:32', versions: ['>=1.0.0', '<1.2.0'] }
+    1.2.x:
+        time: '2019-02-13 17:13:22'
+        versions: ['>=1.0.0', '<1.2.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/focal_point'

--- a/drupal/focal_point/sa-contrib-2019-015.yaml
+++ b/drupal/focal_point/sa-contrib-2019-015.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-015'
+title: 'Focal Point - Moderately critical - Cross site scripting - SA-CONTRIB-2019-015'
+branches:
+    1.2.x: { time: '2019-02-13 16:38:32', versions: ['>=1.0.0', '<1.2.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/focal_point'

--- a/drupal/fontawesome/sa-contrib-2019-025.yaml
+++ b/drupal/fontawesome/sa-contrib-2019-025.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-025'
 title: 'Font Awesome Icons - Critical - Remote Code Execution - SA-CONTRIB-2019-025'
 branches:
-    2.12.x: { time: '2019-02-20 16:38:33', versions: ['>=2.0.0', '<2.12.0'] }
+    2.12.x:
+        time: '2019-02-20 17:13:22'
+        versions: ['>=2.0.0', '<2.12.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/fontawesome'

--- a/drupal/fontawesome/sa-contrib-2019-025.yaml
+++ b/drupal/fontawesome/sa-contrib-2019-025.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-025'
+title: 'Font Awesome Icons - Critical - Remote Code Execution - SA-CONTRIB-2019-025'
+branches:
+    2.12.x: { time: '2019-02-20 16:38:33', versions: ['>=2.0.0', '<2.12.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/fontawesome'

--- a/drupal/fraction/sa-contrib-2018-059.yaml
+++ b/drupal/fraction/sa-contrib-2018-059.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-059'
 title: 'Fraction - Less critical - XSS vulnerability - SA-CONTRIB-2018-059'
 branches:
-    1.2.x: { time: '2018-09-05 16:38:32', versions: ['>=1.0.0', '<1.2.0'] }
+    1.2.x:
+        time: '2018-09-05 17:13:21'
+        versions: ['>=1.0.0', '<1.2.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/fraction'

--- a/drupal/fraction/sa-contrib-2018-059.yaml
+++ b/drupal/fraction/sa-contrib-2018-059.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-059'
+title: 'Fraction - Less critical - XSS vulnerability - SA-CONTRIB-2018-059'
+branches:
+    1.2.x: { time: '2018-09-05 16:38:32', versions: ['>=1.0.0', '<1.2.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/fraction'

--- a/drupal/gathercontent/sa-contrib-2018-075.yaml
+++ b/drupal/gathercontent/sa-contrib-2018-075.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-075'
+title: 'GatherContent - Moderately critical - Access bypass - SA-CONTRIB-2018-075'
+branches:
+    3.5.x: { time: '2018-11-28 16:38:32', versions: ['>=3.0.0', '<3.5.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/gathercontent'

--- a/drupal/gathercontent/sa-contrib-2018-075.yaml
+++ b/drupal/gathercontent/sa-contrib-2018-075.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-075'
 title: 'GatherContent - Moderately critical - Access bypass - SA-CONTRIB-2018-075'
 branches:
-    3.5.x: { time: '2018-11-28 16:38:32', versions: ['>=3.0.0', '<3.5.0'] }
+    3.5.x:
+        time: '2018-11-28 17:13:21'
+        versions: ['>=3.0.0', '<3.5.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/gathercontent'

--- a/drupal/genpass/sa-contrib-2018-042.yaml
+++ b/drupal/genpass/sa-contrib-2018-042.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-042'
 title: 'Generate Password  - Less critical - Insecure Randomness - SA-CONTRIB-2018-042'
 branches:
-    1.1.x: { time: '2018-06-27 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-06-27 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/genpass'

--- a/drupal/genpass/sa-contrib-2018-042.yaml
+++ b/drupal/genpass/sa-contrib-2018-042.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-042'
+title: 'Generate Password  - Less critical - Insecure Randomness - SA-CONTRIB-2018-042'
+branches:
+    1.1.x: { time: '2018-06-27 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/genpass'

--- a/drupal/hosting_https/sa-contrib-2019-003.yaml
+++ b/drupal/hosting_https/sa-contrib-2019-003.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-003'
 title: 'Aegir HTTPS - Moderately critical - Access bypass - SA-CONTRIB-2019-003'
 branches:
-    3.170.x: { time: '2019-01-09 16:38:32', versions: ['>=3.0.0', '<3.170.0'] }
+    3.170.x:
+        time: '2019-01-09 17:13:22'
+        versions: ['>=3.0.0', '<3.170.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/hosting_https'

--- a/drupal/hosting_https/sa-contrib-2019-003.yaml
+++ b/drupal/hosting_https/sa-contrib-2019-003.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-003'
+title: 'Aegir HTTPS - Moderately critical - Access bypass - SA-CONTRIB-2019-003'
+branches:
+    3.170.x: { time: '2019-01-09 16:38:32', versions: ['>=3.0.0', '<3.170.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/hosting_https'

--- a/drupal/jsonapi/sa-contrib-2018-015.yaml
+++ b/drupal/jsonapi/sa-contrib-2018-015.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-015'
+title: 'JSON API - Moderately critical - Multiple Vulnerabilities  - SA-CONTRIB-2018-015'
+branches:
+    1.10.x: { time: '2018-02-21 16:38:31', versions: ['>=1.0.0', '<1.10.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/jsonapi'

--- a/drupal/jsonapi/sa-contrib-2018-015.yaml
+++ b/drupal/jsonapi/sa-contrib-2018-015.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-015'
 title: 'JSON API - Moderately critical - Multiple Vulnerabilities  - SA-CONTRIB-2018-015'
 branches:
-    1.10.x: { time: '2018-02-21 16:38:31', versions: ['>=1.0.0', '<1.10.0'] }
+    1.10.x:
+        time: '2018-02-21 17:13:21'
+        versions: ['>=1.0.0', '<1.10.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/jsonapi'

--- a/drupal/jsonapi/sa-contrib-2018-016.yaml
+++ b/drupal/jsonapi/sa-contrib-2018-016.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-016'
+title: 'JSON API - Moderately critical - Access Bypass - SA-CONTRIB-2018-016'
+branches:
+    1.14.x: { time: '2018-03-21 16:38:31', versions: ['>=1.0.0', '<1.14.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/jsonapi'

--- a/drupal/jsonapi/sa-contrib-2018-016.yaml
+++ b/drupal/jsonapi/sa-contrib-2018-016.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-016'
 title: 'JSON API - Moderately critical - Access Bypass - SA-CONTRIB-2018-016'
 branches:
-    1.14.x: { time: '2018-03-21 16:38:31', versions: ['>=1.0.0', '<1.14.0'] }
+    1.14.x:
+        time: '2018-03-21 17:13:21'
+        versions: ['>=1.0.0', '<1.14.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/jsonapi'

--- a/drupal/jsonapi/sa-contrib-2018-021.yaml
+++ b/drupal/jsonapi/sa-contrib-2018-021.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-021'
 title: 'JSON API - Moderately critical - Cross Site Request Forgery - SA-CONTRIB-2018-021'
 branches:
-    1.16.x: { time: '2018-04-25 16:38:31', versions: ['>=1.0.0', '<1.16.0'] }
+    1.16.x:
+        time: '2018-04-25 17:13:21'
+        versions: ['>=1.0.0', '<1.16.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/jsonapi'

--- a/drupal/jsonapi/sa-contrib-2018-021.yaml
+++ b/drupal/jsonapi/sa-contrib-2018-021.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-021'
+title: 'JSON API - Moderately critical - Cross Site Request Forgery - SA-CONTRIB-2018-021'
+branches:
+    1.16.x: { time: '2018-04-25 16:38:31', versions: ['>=1.0.0', '<1.16.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/jsonapi'

--- a/drupal/lightbox2/sa-contrib-2018-064.yaml
+++ b/drupal/lightbox2/sa-contrib-2018-064.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-064'
 title: 'Lightbox2 - Critical - Cross Site Scripting - SA-CONTRIB-2018-064'
 branches:
-    2.11.x: { time: '2018-10-10 16:38:32', versions: ['>=2.0.0', '<2.11.0'] }
+    2.11.x:
+        time: '2018-10-10 17:13:21'
+        versions: ['>=2.0.0', '<2.11.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/lightbox2'

--- a/drupal/lightbox2/sa-contrib-2018-064.yaml
+++ b/drupal/lightbox2/sa-contrib-2018-064.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-064'
+title: 'Lightbox2 - Critical - Cross Site Scripting - SA-CONTRIB-2018-064'
+branches:
+    2.11.x: { time: '2018-10-10 16:38:32', versions: ['>=2.0.0', '<2.11.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/lightbox2'

--- a/drupal/link/sa-contrib-2019-020.yaml
+++ b/drupal/link/sa-contrib-2019-020.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-020'
 title: 'Link - Critical - Remote Code Execution - SA-CONTRIB-2019-020'
 branches:
-    1.6.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.6.0'] }
+    1.6.x:
+        time: '2019-02-20 17:13:22'
+        versions: ['>=1.0.0', '<1.6.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/link'

--- a/drupal/link/sa-contrib-2019-020.yaml
+++ b/drupal/link/sa-contrib-2019-020.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-020'
+title: 'Link - Critical - Remote Code Execution - SA-CONTRIB-2019-020'
+branches:
+    1.6.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.6.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/link'

--- a/drupal/litejazz/sa-contrib-2018-050.yaml
+++ b/drupal/litejazz/sa-contrib-2018-050.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-050'
 title: 'litejazz - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-050'
 branches:
-    2.3.x: { time: '2018-07-11 16:38:32', versions: ['>=2.0.0', '<2.3.0'] }
+    2.3.x:
+        time: '2018-07-11 17:13:21'
+        versions: ['>=2.0.0', '<2.3.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/litejazz'

--- a/drupal/litejazz/sa-contrib-2018-050.yaml
+++ b/drupal/litejazz/sa-contrib-2018-050.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-050'
+title: 'litejazz - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-050'
+branches:
+    2.3.x: { time: '2018-07-11 16:38:32', versions: ['>=2.0.0', '<2.3.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/litejazz'

--- a/drupal/mailhandler/sa-contrib-2017-089.yaml
+++ b/drupal/mailhandler/sa-contrib-2017-089.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-089'
+title: 'Mailhandler - Critical - Remote Code Execution - SA-CONTRIB-2017-089'
+branches:
+    2.11.x: { time: '2017-12-06 16:38:31', versions: ['>=2.0.0', '<2.11.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/mailhandler'

--- a/drupal/mailhandler/sa-contrib-2017-089.yaml
+++ b/drupal/mailhandler/sa-contrib-2017-089.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-089'
 title: 'Mailhandler - Critical - Remote Code Execution - SA-CONTRIB-2017-089'
 branches:
-    2.11.x: { time: '2017-12-06 16:38:31', versions: ['>=2.0.0', '<2.11.0'] }
+    2.11.x:
+        time: '2017-12-06 17:13:21'
+        versions: ['>=2.0.0', '<2.11.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/mailhandler'

--- a/drupal/mass_pwreset/sa-contrib-2018-043.yaml
+++ b/drupal/mass_pwreset/sa-contrib-2018-043.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-043'
+title: 'Mass Password Reset - Less critical - Insecure Randomness - SA-CONTRIB-2018-043'
+branches:
+    1.1.x: { time: '2018-06-27 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/mass_pwreset'

--- a/drupal/mass_pwreset/sa-contrib-2018-043.yaml
+++ b/drupal/mass_pwreset/sa-contrib-2018-043.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-043'
 title: 'Mass Password Reset - Less critical - Insecure Randomness - SA-CONTRIB-2018-043'
 branches:
-    1.1.x: { time: '2018-06-27 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-06-27 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/mass_pwreset'

--- a/drupal/me/sa-contrib-2017-097.yaml
+++ b/drupal/me/sa-contrib-2017-097.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-097'
 title: 'me aliases - Highly critical - Arbitrary code execution - SA-CONTRIB-2017-097'
 branches:
-    1.3.x: { time: '2017-12-20 16:38:31', versions: ['>=1.0.0', '<1.3.0'] }
+    1.3.x:
+        time: '2017-12-20 17:13:21'
+        versions: ['>=1.0.0', '<1.3.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/me'

--- a/drupal/me/sa-contrib-2017-097.yaml
+++ b/drupal/me/sa-contrib-2017-097.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-097'
+title: 'me aliases - Highly critical - Arbitrary code execution - SA-CONTRIB-2017-097'
+branches:
+    1.3.x: { time: '2017-12-20 16:38:31', versions: ['>=1.0.0', '<1.3.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/me'

--- a/drupal/media/sa-contrib-2018-020.yaml
+++ b/drupal/media/sa-contrib-2018-020.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-020'
 title: 'Media - Critical - Remote Code Execution - SA-CONTRIB-2018-020'
 branches:
-    2.19.x: { time: '2018-04-25 16:38:31', versions: ['>=2.0.0', '<2.19.0'] }
+    2.19.x:
+        time: '2018-04-25 17:13:21'
+        versions: ['>=2.0.0', '<2.19.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/media'

--- a/drupal/media/sa-contrib-2018-020.yaml
+++ b/drupal/media/sa-contrib-2018-020.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-020'
+title: 'Media - Critical - Remote Code Execution - SA-CONTRIB-2018-020'
+branches:
+    2.19.x: { time: '2018-04-25 16:38:31', versions: ['>=2.0.0', '<2.19.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/media'

--- a/drupal/menu_export/sa-contrib-2018-018.yaml
+++ b/drupal/menu_export/sa-contrib-2018-018.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-018'
 title: 'Menu Import and Export - Critical - Access bypass - SA-CONTRIB-2018-018'
 branches:
-    1.2.x: { time: '2018-04-18 16:38:31', versions: ['>=1.0.0', '<1.2.0'] }
+    1.2.x:
+        time: '2018-04-18 17:13:21'
+        versions: ['>=1.0.0', '<1.2.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/menu_export'

--- a/drupal/menu_export/sa-contrib-2018-018.yaml
+++ b/drupal/menu_export/sa-contrib-2018-018.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-018'
+title: 'Menu Import and Export - Critical - Access bypass - SA-CONTRIB-2018-018'
+branches:
+    1.2.x: { time: '2018-04-18 16:38:31', versions: ['>=1.0.0', '<1.2.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/menu_export'

--- a/drupal/metatag/sa-contrib-2019-021.yaml
+++ b/drupal/metatag/sa-contrib-2019-021.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-021'
+title: 'Metatag - Critical - Remote code execution - SA-CONTRIB-2019-021'
+branches:
+    1.8.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.8.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/metatag'

--- a/drupal/metatag/sa-contrib-2019-021.yaml
+++ b/drupal/metatag/sa-contrib-2019-021.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-021'
 title: 'Metatag - Critical - Remote code execution - SA-CONTRIB-2019-021'
 branches:
-    1.8.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.8.0'] }
+    1.8.x:
+        time: '2019-02-20 17:13:22'
+        versions: ['>=1.0.0', '<1.8.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/metatag'

--- a/drupal/miniorange_oauth_client/sa-contrib-2019-016.yaml
+++ b/drupal/miniorange_oauth_client/sa-contrib-2019-016.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-016'
 title: 'OAuth 2.0 Client Login (Single Sign-On) - Critical - Multiple Vulnerabilities  - SA-CONTRIB-2019-016'
 branches:
-    1.21.x: { time: '2019-02-13 16:38:33', versions: ['>=1.0.0', '<1.21.0'] }
+    1.21.x:
+        time: '2019-02-13 17:13:22'
+        versions: ['>=1.0.0', '<1.21.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/miniorange_oauth_client'

--- a/drupal/miniorange_oauth_client/sa-contrib-2019-016.yaml
+++ b/drupal/miniorange_oauth_client/sa-contrib-2019-016.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-016'
+title: 'OAuth 2.0 Client Login (Single Sign-On) - Critical - Multiple Vulnerabilities  - SA-CONTRIB-2019-016'
+branches:
+    1.21.x: { time: '2019-02-13 16:38:33', versions: ['>=1.0.0', '<1.21.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/miniorange_oauth_client'

--- a/drupal/moneysuite/sa-contrib-2017-085.yaml
+++ b/drupal/moneysuite/sa-contrib-2017-085.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-085'
 title: 'MoneySuite - Moderately critical - Access bypass - SA-CONTRIB-2017-085'
 branches:
-    10.4.x: { time: '2017-11-29 16:38:31', versions: ['>=10.0.0', '<10.4.0'] }
+    10.4.x:
+        time: '2017-11-29 17:13:20'
+        versions: ['>=10.0.0', '<10.4.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/moneysuite'

--- a/drupal/moneysuite/sa-contrib-2017-085.yaml
+++ b/drupal/moneysuite/sa-contrib-2017-085.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-085'
+title: 'MoneySuite - Moderately critical - Access bypass - SA-CONTRIB-2017-085'
+branches:
+    10.4.x: { time: '2017-11-29 16:38:31', versions: ['>=10.0.0', '<10.4.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/moneysuite'

--- a/drupal/mosaik/sa-contrib-2017-080.yaml
+++ b/drupal/mosaik/sa-contrib-2017-080.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-080'
 title: 'Mosaik - Moderately critical - Cross-site scripting - SA-CONTRIB-2017-080'
 branches:
-    1.2.x: { time: '2017-10-25 16:38:31', versions: ['>=1.0.0', '<1.2.0'] }
+    1.2.x:
+        time: '2017-10-25 17:13:20'
+        versions: ['>=1.0.0', '<1.2.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/mosaik'

--- a/drupal/mosaik/sa-contrib-2017-080.yaml
+++ b/drupal/mosaik/sa-contrib-2017-080.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-080'
+title: 'Mosaik - Moderately critical - Cross-site scripting - SA-CONTRIB-2017-080'
+branches:
+    1.2.x: { time: '2017-10-25 16:38:31', versions: ['>=1.0.0', '<1.2.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/mosaik'

--- a/drupal/netforum_authentication/sa-contrib-2017-077.yaml
+++ b/drupal/netforum_authentication/sa-contrib-2017-077.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-077'
+title: 'netFORUM Authentication - Moderately critical - Access Bypass - SA-CONTRIB-2017-077'
+branches:
+    1.1.x: { time: '2017-10-11 16:38:30', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/netforum_authentication'

--- a/drupal/netforum_authentication/sa-contrib-2017-077.yaml
+++ b/drupal/netforum_authentication/sa-contrib-2017-077.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-077'
 title: 'netFORUM Authentication - Moderately critical - Access Bypass - SA-CONTRIB-2017-077'
 branches:
-    1.1.x: { time: '2017-10-11 16:38:30', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2017-10-11 17:13:20'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/netforum_authentication'

--- a/drupal/newsflash/sa-contrib-2018-049.yaml
+++ b/drupal/newsflash/sa-contrib-2018-049.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-049'
+title: 'NewsFlash - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-049'
+branches:
+    2.6.x: { time: '2018-07-11 16:38:32', versions: ['>=2.0.0', '<2.6.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/newsflash'

--- a/drupal/newsflash/sa-contrib-2018-049.yaml
+++ b/drupal/newsflash/sa-contrib-2018-049.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-049'
 title: 'NewsFlash - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-049'
 branches:
-    2.6.x: { time: '2018-07-11 16:38:32', versions: ['>=2.0.0', '<2.6.0'] }
+    2.6.x:
+        time: '2018-07-11 17:13:21'
+        versions: ['>=2.0.0', '<2.6.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/newsflash'

--- a/drupal/node_feedback/sa-contrib-2017-092.yaml
+++ b/drupal/node_feedback/sa-contrib-2017-092.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-092'
+title: 'Node feedback - Moderately critical - Access Bypass - SA-CONTRIB-2017-092'
+branches:
+    1.3.x: { time: '2017-12-06 16:38:31', versions: ['>=1.0.0', '<1.3.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/node_feedback'

--- a/drupal/node_feedback/sa-contrib-2017-092.yaml
+++ b/drupal/node_feedback/sa-contrib-2017-092.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-092'
 title: 'Node feedback - Moderately critical - Access Bypass - SA-CONTRIB-2017-092'
 branches:
-    1.3.x: { time: '2017-12-06 16:38:31', versions: ['>=1.0.0', '<1.3.0'] }
+    1.3.x:
+        time: '2017-12-06 17:13:21'
+        versions: ['>=1.0.0', '<1.3.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/node_feedback'

--- a/drupal/node_view_permissions/sa-contrib-2018-002.yaml
+++ b/drupal/node_view_permissions/sa-contrib-2018-002.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-002'
+title: 'Node View Permissions - Moderately critical - Access Bypass - SA-CONTRIB-2018-002'
+branches:
+    1.1.x: { time: '2018-01-10 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/node_view_permissions'

--- a/drupal/node_view_permissions/sa-contrib-2018-002.yaml
+++ b/drupal/node_view_permissions/sa-contrib-2018-002.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-002'
 title: 'Node View Permissions - Moderately critical - Access Bypass - SA-CONTRIB-2018-002'
 branches:
-    1.1.x: { time: '2018-01-10 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-01-10 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/node_view_permissions'

--- a/drupal/nucleus/sa-contrib-2018-031.yaml
+++ b/drupal/nucleus/sa-contrib-2018-031.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-031'
+title: 'TB Nucleus - Critical - Unsupported - SA-CONTRIB-2018-031'
+branches:
+    1.6.x: { time: '2018-05-23 16:38:31', versions: ['>=1.0.0', '<1.6.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/nucleus'

--- a/drupal/nucleus/sa-contrib-2018-031.yaml
+++ b/drupal/nucleus/sa-contrib-2018-031.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-031'
 title: 'TB Nucleus - Critical - Unsupported - SA-CONTRIB-2018-031'
 branches:
-    1.6.x: { time: '2018-05-23 16:38:31', versions: ['>=1.0.0', '<1.6.0'] }
+    1.6.x:
+        time: '2018-05-23 17:13:21'
+        versions: ['>=1.0.0', '<1.6.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/nucleus'

--- a/drupal/nvp/sa-contrib-2018-066.yaml
+++ b/drupal/nvp/sa-contrib-2018-066.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-066'
+title: 'NVP field - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-066'
+branches:
+    1.1.x: { time: '2018-10-10 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/nvp'

--- a/drupal/nvp/sa-contrib-2018-066.yaml
+++ b/drupal/nvp/sa-contrib-2018-066.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-066'
 title: 'NVP field - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-066'
 branches:
-    1.1.x: { time: '2018-10-10 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-10-10 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/nvp'

--- a/drupal/panels_breadcrumbs/sa-contrib-2019-007.yaml
+++ b/drupal/panels_breadcrumbs/sa-contrib-2019-007.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-007'
+title: 'Panels Breadcrumbs - Moderately critical - Cross site scripting - SA-CONTRIB-2019-007'
+branches:
+    2.4.x: { time: '2019-01-23 16:38:32', versions: ['>=2.0.0', '<2.4.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/panels_breadcrumbs'

--- a/drupal/panels_breadcrumbs/sa-contrib-2019-007.yaml
+++ b/drupal/panels_breadcrumbs/sa-contrib-2019-007.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-007'
 title: 'Panels Breadcrumbs - Moderately critical - Cross site scripting - SA-CONTRIB-2019-007'
 branches:
-    2.4.x: { time: '2019-01-23 16:38:32', versions: ['>=2.0.0', '<2.4.0'] }
+    2.4.x:
+        time: '2019-01-23 17:13:22'
+        versions: ['>=2.0.0', '<2.4.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/panels_breadcrumbs'

--- a/drupal/panopoly_core/sa-contrib-2017-093.yaml
+++ b/drupal/panopoly_core/sa-contrib-2017-093.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-093'
 title: 'Panopoly Core - Moderately critical - Cross Site Scripting - SA-CONTRIB-2017-093'
 branches:
-    1.49.x: { time: '2017-12-13 16:38:31', versions: ['>=1.0.0', '<1.49.0'] }
+    1.49.x:
+        time: '2017-12-13 17:13:21'
+        versions: ['>=1.0.0', '<1.49.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/panopoly_core'

--- a/drupal/panopoly_core/sa-contrib-2017-093.yaml
+++ b/drupal/panopoly_core/sa-contrib-2017-093.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-093'
+title: 'Panopoly Core - Moderately critical - Cross Site Scripting - SA-CONTRIB-2017-093'
+branches:
+    1.49.x: { time: '2017-12-13 16:38:31', versions: ['>=1.0.0', '<1.49.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/panopoly_core'

--- a/drupal/paragraphs/sa-contrib-2019-023.yaml
+++ b/drupal/paragraphs/sa-contrib-2019-023.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-023'
+title: 'Paragraphs - Critical - Remote Code Execution - SA-CONTRIB-2019-023'
+branches:
+    1.6.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.6.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/paragraphs'

--- a/drupal/paragraphs/sa-contrib-2019-023.yaml
+++ b/drupal/paragraphs/sa-contrib-2019-023.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-023'
 title: 'Paragraphs - Critical - Remote Code Execution - SA-CONTRIB-2019-023'
 branches:
-    1.6.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.6.0'] }
+    1.6.x:
+        time: '2019-02-20 17:13:22'
+        versions: ['>=1.0.0', '<1.6.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/paragraphs'

--- a/drupal/password_policy/sa-contrib-2018-077.yaml
+++ b/drupal/password_policy/sa-contrib-2018-077.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-077'
+title: 'Password Policy - Less critical - Denial of Service - SA-CONTRIB-2018-077'
+branches:
+    1.16.x: { time: '2018-12-05 16:38:32', versions: ['>=1.0.0', '<1.16.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/password_policy'

--- a/drupal/password_policy/sa-contrib-2018-077.yaml
+++ b/drupal/password_policy/sa-contrib-2018-077.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-077'
 title: 'Password Policy - Less critical - Denial of Service - SA-CONTRIB-2018-077'
 branches:
-    1.16.x: { time: '2018-12-05 16:38:32', versions: ['>=1.0.0', '<1.16.0'] }
+    1.16.x:
+        time: '2018-12-05 17:13:21'
+        versions: ['>=1.0.0', '<1.16.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/password_policy'

--- a/drupal/permissions_by_term/sa-contrib-2017-082.yaml
+++ b/drupal/permissions_by_term/sa-contrib-2017-082.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-082'
+title: 'Permissions by Term - Moderately critical - Access bypass - SA-CONTRIB-2017-082'
+branches:
+    1.35.x: { time: '2017-11-08 16:38:31', versions: ['>=1.0.0', '<1.35.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/permissions_by_term'

--- a/drupal/permissions_by_term/sa-contrib-2017-082.yaml
+++ b/drupal/permissions_by_term/sa-contrib-2017-082.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-082'
 title: 'Permissions by Term - Moderately critical - Access bypass - SA-CONTRIB-2017-082'
 branches:
-    1.35.x: { time: '2017-11-08 16:38:31', versions: ['>=1.0.0', '<1.35.0'] }
+    1.35.x:
+        time: '2017-11-08 17:13:20'
+        versions: ['>=1.0.0', '<1.35.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/permissions_by_term'

--- a/drupal/phonefield/sa-contrib-2019-001.yaml
+++ b/drupal/phonefield/sa-contrib-2019-001.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-001'
+title: 'Phone Field - Critical - SQL Injection - SA-CONTRIB-2019-001'
+branches:
+    1.1.x: { time: '2019-01-09 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/phonefield'

--- a/drupal/phonefield/sa-contrib-2019-001.yaml
+++ b/drupal/phonefield/sa-contrib-2019-001.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-001'
 title: 'Phone Field - Critical - SQL Injection - SA-CONTRIB-2019-001'
 branches:
-    1.1.x: { time: '2019-01-09 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2019-01-09 17:13:22'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/phonefield'

--- a/drupal/phpconfig/sa-contrib-2018-055.yaml
+++ b/drupal/phpconfig/sa-contrib-2018-055.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-055'
 title: 'PHP Configuration - Critical - Arbitrary PHP code execution - SA-CONTRIB-2018-055'
 branches:
-    1.1.x: { time: '2018-08-08 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-08-08 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/phpconfig'

--- a/drupal/phpconfig/sa-contrib-2018-055.yaml
+++ b/drupal/phpconfig/sa-contrib-2018-055.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-055'
+title: 'PHP Configuration - Critical - Arbitrary PHP code execution - SA-CONTRIB-2018-055'
+branches:
+    1.1.x: { time: '2018-08-08 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/phpconfig'

--- a/drupal/preview_link/sa-contrib-2019-004.yaml
+++ b/drupal/preview_link/sa-contrib-2019-004.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-004'
 title: 'Preview Link - Moderately critical - Access bypass - SA-CONTRIB-2019-004'
 branches:
-    1.1.x: { time: '2019-01-23 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2019-01-23 17:13:22'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/preview_link'

--- a/drupal/preview_link/sa-contrib-2019-004.yaml
+++ b/drupal/preview_link/sa-contrib-2019-004.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-004'
+title: 'Preview Link - Moderately critical - Access bypass - SA-CONTRIB-2019-004'
+branches:
+    1.1.x: { time: '2019-01-23 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/preview_link'

--- a/drupal/print/sa-contrib-2018-063.yaml
+++ b/drupal/print/sa-contrib-2018-063.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-063'
+title: 'Printer, email and PDF versions - Highly critical - Remote Code Execution - SA-CONTRIB-2018-063'
+branches:
+    2.1.x: { time: '2018-10-03 16:38:32', versions: ['>=2.0.0', '<2.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/print'

--- a/drupal/print/sa-contrib-2018-063.yaml
+++ b/drupal/print/sa-contrib-2018-063.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-063'
 title: 'Printer, email and PDF versions - Highly critical - Remote Code Execution - SA-CONTRIB-2018-063'
 branches:
-    2.1.x: { time: '2018-10-03 16:38:32', versions: ['>=2.0.0', '<2.1.0'] }
+    2.1.x:
+        time: '2018-10-03 17:13:21'
+        versions: ['>=2.0.0', '<2.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/print'

--- a/drupal/provision/sa-contrib-2019-002.yaml
+++ b/drupal/provision/sa-contrib-2019-002.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-002'
+title: 'Provision - Moderately critical - Access bypass - SA-CONTRIB-2019-002'
+branches:
+    3.170.x: { time: '2019-01-09 16:38:32', versions: ['>=3.0.0', '<3.170.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/provision'

--- a/drupal/provision/sa-contrib-2019-002.yaml
+++ b/drupal/provision/sa-contrib-2019-002.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-002'
 title: 'Provision - Moderately critical - Access bypass - SA-CONTRIB-2019-002'
 branches:
-    3.170.x: { time: '2019-01-09 16:38:32', versions: ['>=3.0.0', '<3.170.0'] }
+    3.170.x:
+        time: '2019-01-09 17:13:22'
+        versions: ['>=3.0.0', '<3.170.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/provision'

--- a/drupal/pubdlcnt/sa-contrib-2019-012.yaml
+++ b/drupal/pubdlcnt/sa-contrib-2019-012.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-012'
+title: 'Public Download Count - Less critical - Open Redirect Vulnerability - SA-CONTRIB-2019-012'
+branches:
+    1.3.x: { time: '2019-02-06 16:38:32', versions: ['>=1.0.0', '<1.3.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/pubdlcnt'

--- a/drupal/pubdlcnt/sa-contrib-2019-012.yaml
+++ b/drupal/pubdlcnt/sa-contrib-2019-012.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-012'
 title: 'Public Download Count - Less critical - Open Redirect Vulnerability - SA-CONTRIB-2019-012'
 branches:
-    1.3.x: { time: '2019-02-06 16:38:32', versions: ['>=1.0.0', '<1.3.0'] }
+    1.3.x:
+        time: '2019-02-06 17:13:22'
+        versions: ['>=1.0.0', '<1.3.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/pubdlcnt'

--- a/drupal/renderkit/sa-contrib-2018-060.yaml
+++ b/drupal/renderkit/sa-contrib-2018-060.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-060'
 title: 'Renderkit - Moderately critical - Access bypass - SA-CONTRIB-2018-060'
 branches:
-    1.6.x: { time: '2018-09-19 16:38:32', versions: ['>=1.0.0', '<1.6.0'] }
+    1.6.x:
+        time: '2018-09-19 17:13:21'
+        versions: ['>=1.0.0', '<1.6.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/renderkit'

--- a/drupal/renderkit/sa-contrib-2018-060.yaml
+++ b/drupal/renderkit/sa-contrib-2018-060.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-060'
+title: 'Renderkit - Moderately critical - Access bypass - SA-CONTRIB-2018-060'
+branches:
+    1.6.x: { time: '2018-09-19 16:38:32', versions: ['>=1.0.0', '<1.6.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/renderkit'

--- a/drupal/responsive_menus/sa-contrib-2018-079.yaml
+++ b/drupal/responsive_menus/sa-contrib-2018-079.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-079'
+title: 'Responsive Menus - Moderately critical - Cross site scripting - SA-CONTRIB-2018-079'
+branches:
+    1.7.x: { time: '2018-12-05 16:38:32', versions: ['>=1.0.0', '<1.7.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/responsive_menus'

--- a/drupal/responsive_menus/sa-contrib-2018-079.yaml
+++ b/drupal/responsive_menus/sa-contrib-2018-079.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-079'
 title: 'Responsive Menus - Moderately critical - Cross site scripting - SA-CONTRIB-2018-079'
 branches:
-    1.7.x: { time: '2018-12-05 16:38:32', versions: ['>=1.0.0', '<1.7.0'] }
+    1.7.x:
+        time: '2018-12-05 17:13:21'
+        versions: ['>=1.0.0', '<1.7.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/responsive_menus'

--- a/drupal/restws/sa-contrib-2019-018.yaml
+++ b/drupal/restws/sa-contrib-2019-018.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-018'
 title: 'RESTful Web Services - Critical - Access bypass - SA-CONTRIB-2019-018'
 branches:
-    2.8.x: { time: '2019-02-20 16:38:33', versions: ['>=2.0.0', '<2.8.0'] }
+    2.8.x:
+        time: '2019-02-20 17:13:22'
+        versions: ['>=2.0.0', '<2.8.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/restws'

--- a/drupal/restws/sa-contrib-2019-018.yaml
+++ b/drupal/restws/sa-contrib-2019-018.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-018'
+title: 'RESTful Web Services - Critical - Access bypass - SA-CONTRIB-2019-018'
+branches:
+    2.8.x: { time: '2019-02-20 16:38:33', versions: ['>=2.0.0', '<2.8.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/restws'

--- a/drupal/sagepay_payment/sa-contrib-2018-005.yaml
+++ b/drupal/sagepay_payment/sa-contrib-2018-005.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-005'
 title: 'Sagepay - Critical - Access Bypass - SA-CONTRIB-2018-005'
 branches:
-    1.5.x: { time: '2018-01-31 16:38:31', versions: ['>=1.0.0', '<1.5.0'] }
+    1.5.x:
+        time: '2018-01-31 17:13:21'
+        versions: ['>=1.0.0', '<1.5.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/sagepay_payment'

--- a/drupal/sagepay_payment/sa-contrib-2018-005.yaml
+++ b/drupal/sagepay_payment/sa-contrib-2018-005.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-005'
+title: 'Sagepay - Critical - Access Bypass - SA-CONTRIB-2018-005'
+branches:
+    1.5.x: { time: '2018-01-31 16:38:31', versions: ['>=1.0.0', '<1.5.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/sagepay_payment'

--- a/drupal/salesforce/sa-contrib-2018-078.yaml
+++ b/drupal/salesforce/sa-contrib-2018-078.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-078'
 title: 'Salesforce Suite - Moderately critical - Access bypass - SA-CONTRIB-2018-078'
 branches:
-    3.1.x: { time: '2018-12-05 16:38:32', versions: ['>=3.0.0', '<3.1.0'] }
+    3.1.x:
+        time: '2018-12-05 17:13:21'
+        versions: ['>=3.0.0', '<3.1.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/salesforce'

--- a/drupal/salesforce/sa-contrib-2018-078.yaml
+++ b/drupal/salesforce/sa-contrib-2018-078.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-078'
+title: 'Salesforce Suite - Moderately critical - Access bypass - SA-CONTRIB-2018-078'
+branches:
+    3.1.x: { time: '2018-12-05 16:38:32', versions: ['>=3.0.0', '<3.1.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/salesforce'

--- a/drupal/search_api_solr/sa-contrib-2018-065.yaml
+++ b/drupal/search_api_solr/sa-contrib-2018-065.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-065'
 title: 'Search API Solr Search - Moderately critical - Access bypass - SA-CONTRIB-2018-065'
 branches:
-    1.14.x: { time: '2018-10-10 16:38:32', versions: ['>=1.0.0', '<1.14.0'] }
+    1.14.x:
+        time: '2018-10-10 17:13:21'
+        versions: ['>=1.0.0', '<1.14.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/search_api_solr'

--- a/drupal/search_api_solr/sa-contrib-2018-065.yaml
+++ b/drupal/search_api_solr/sa-contrib-2018-065.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-065'
+title: 'Search API Solr Search - Moderately critical - Access bypass - SA-CONTRIB-2018-065'
+branches:
+    1.14.x: { time: '2018-10-10 16:38:32', versions: ['>=1.0.0', '<1.14.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/search_api_solr'

--- a/drupal/search_autocomplete/sa-contrib-2018-070.yaml
+++ b/drupal/search_autocomplete/sa-contrib-2018-070.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-070'
+title: 'Search Autocomplete - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-070'
+branches:
+    4.8.x: { time: '2018-10-17 16:38:32', versions: ['>=4.0.0', '<4.8.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/search_autocomplete'

--- a/drupal/search_autocomplete/sa-contrib-2018-070.yaml
+++ b/drupal/search_autocomplete/sa-contrib-2018-070.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-070'
 title: 'Search Autocomplete - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-070'
 branches:
-    4.8.x: { time: '2018-10-17 16:38:32', versions: ['>=4.0.0', '<4.8.0'] }
+    4.8.x:
+        time: '2018-10-17 17:13:21'
+        versions: ['>=4.0.0', '<4.8.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/search_autocomplete'

--- a/drupal/services_sso_client/sa-contrib-2017-087.yaml
+++ b/drupal/services_sso_client/sa-contrib-2017-087.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-087'
+title: 'Services single sign-on client - Critical - Cross-site scripting - SA-CONTRIB-2017-087'
+branches:
+    1.6.x: { time: '2017-11-29 16:38:31', versions: ['>=1.0.0', '<1.6.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/services_sso_client'

--- a/drupal/services_sso_client/sa-contrib-2017-087.yaml
+++ b/drupal/services_sso_client/sa-contrib-2017-087.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-087'
 title: 'Services single sign-on client - Critical - Cross-site scripting - SA-CONTRIB-2017-087'
 branches:
-    1.6.x: { time: '2017-11-29 16:38:31', versions: ['>=1.0.0', '<1.6.0'] }
+    1.6.x:
+        time: '2017-11-29 17:13:21'
+        versions: ['>=1.0.0', '<1.6.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/services_sso_client'

--- a/drupal/stacks/sa-contrib-2018-001.yaml
+++ b/drupal/stacks/sa-contrib-2018-001.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-001'
+title: 'Stacks - Critical - Arbitrary PHP code execution - SA-CONTRIB-2018-001'
+branches:
+    1.1.x: { time: '2018-01-10 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/stacks'

--- a/drupal/stacks/sa-contrib-2018-001.yaml
+++ b/drupal/stacks/sa-contrib-2018-001.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-001'
 title: 'Stacks - Critical - Arbitrary PHP code execution - SA-CONTRIB-2018-001'
 branches:
-    1.1.x: { time: '2018-01-10 16:38:31', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-01-10 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/stacks'

--- a/drupal/tapestry/sa-contrib-2018-051.yaml
+++ b/drupal/tapestry/sa-contrib-2018-051.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-051'
 title: 'Tapestry - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-051'
 branches:
-    2.2.x: { time: '2018-07-11 16:38:32', versions: ['>=2.0.0', '<2.2.0'] }
+    2.2.x:
+        time: '2018-07-11 17:13:21'
+        versions: ['>=2.0.0', '<2.2.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/tapestry'

--- a/drupal/tapestry/sa-contrib-2018-051.yaml
+++ b/drupal/tapestry/sa-contrib-2018-051.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-051'
+title: 'Tapestry - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-051'
+branches:
+    2.2.x: { time: '2018-07-11 16:38:32', versions: ['>=2.0.0', '<2.2.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/tapestry'

--- a/drupal/term_reference_tree/sa-contrib-2018-006.yaml
+++ b/drupal/term_reference_tree/sa-contrib-2018-006.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-006'
+title: 'Taxonomy Term Reference Tree Widget - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-006'
+branches:
+    1.11.x: { time: '2018-01-31 16:38:31', versions: ['>=1.0.0', '<1.11.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/term_reference_tree'

--- a/drupal/term_reference_tree/sa-contrib-2018-006.yaml
+++ b/drupal/term_reference_tree/sa-contrib-2018-006.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-006'
 title: 'Taxonomy Term Reference Tree Widget - Moderately critical - Cross Site Scripting - SA-CONTRIB-2018-006'
 branches:
-    1.11.x: { time: '2018-01-31 16:38:31', versions: ['>=1.0.0', '<1.11.0'] }
+    1.11.x:
+        time: '2018-01-31 17:13:21'
+        versions: ['>=1.0.0', '<1.11.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/term_reference_tree'

--- a/drupal/tfa_basic/sa-contrib-2018-044.yaml
+++ b/drupal/tfa_basic/sa-contrib-2018-044.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-044'
+title: 'TFA Basic plugins - Less critical - Insecure Randomness - SA-CONTRIB-2018-044'
+branches:
+    1.1.x: { time: '2018-06-27 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/tfa_basic'

--- a/drupal/tfa_basic/sa-contrib-2018-044.yaml
+++ b/drupal/tfa_basic/sa-contrib-2018-044.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-044'
 title: 'TFA Basic plugins - Less critical - Insecure Randomness - SA-CONTRIB-2018-044'
 branches:
-    1.1.x: { time: '2018-06-27 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-06-27 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/tfa_basic'

--- a/drupal/tft/sa-contrib-2018-061.yaml
+++ b/drupal/tft/sa-contrib-2018-061.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-061'
 title: 'Taxonomy File Tree - Moderately critical - Access bypass - SA-CONTRIB-2018-061'
 branches:
-    1.1.x: { time: '2018-09-26 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-09-26 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/tft'

--- a/drupal/tft/sa-contrib-2018-061.yaml
+++ b/drupal/tft/sa-contrib-2018-061.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-061'
+title: 'Taxonomy File Tree - Moderately critical - Access bypass - SA-CONTRIB-2018-061'
+branches:
+    1.1.x: { time: '2018-09-26 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/tft'

--- a/drupal/tmgmt/sa-contrib-2019-024.yaml
+++ b/drupal/tmgmt/sa-contrib-2019-024.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-024'
+title: 'Translation Management Tool - Critical - Remote Code Execution - SA-CONTRIB-2019-024'
+branches:
+    1.7.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.7.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/tmgmt'

--- a/drupal/tmgmt/sa-contrib-2019-024.yaml
+++ b/drupal/tmgmt/sa-contrib-2019-024.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-024'
 title: 'Translation Management Tool - Critical - Remote Code Execution - SA-CONTRIB-2019-024'
 branches:
-    1.7.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.7.0'] }
+    1.7.x:
+        time: '2019-02-20 17:13:22'
+        versions: ['>=1.0.0', '<1.7.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/tmgmt'

--- a/drupal/uuid/sa-contrib-2018-045.yaml
+++ b/drupal/uuid/sa-contrib-2018-045.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-045'
 title: 'Universally Unique IDentifier - Moderately critical - Arbitrary file upload - SA-CONTRIB-2018-045'
 branches:
-    1.1.x: { time: '2018-07-04 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+    1.1.x:
+        time: '2018-07-04 17:13:21'
+        versions: ['>=1.0.0', '<1.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/uuid'

--- a/drupal/uuid/sa-contrib-2018-045.yaml
+++ b/drupal/uuid/sa-contrib-2018-045.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-045'
+title: 'Universally Unique IDentifier - Moderately critical - Arbitrary file upload - SA-CONTRIB-2018-045'
+branches:
+    1.1.x: { time: '2018-07-04 16:38:32', versions: ['>=1.0.0', '<1.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/uuid'

--- a/drupal/video/sa-contrib-2019-022.yaml
+++ b/drupal/video/sa-contrib-2019-022.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2019-022'
 title: 'Video - Critical - Remote Code Execution - SA-CONTRIB-2019-022'
 branches:
-    1.4.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.4.0'] }
+    1.4.x:
+        time: '2019-02-20 17:13:22'
+        versions: ['>=1.0.0', '<1.4.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/video'

--- a/drupal/video/sa-contrib-2019-022.yaml
+++ b/drupal/video/sa-contrib-2019-022.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2019-022'
+title: 'Video - Critical - Remote Code Execution - SA-CONTRIB-2019-022'
+branches:
+    1.4.x: { time: '2019-02-20 16:38:33', versions: ['>=1.0.0', '<1.4.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/video'

--- a/drupal/workbench_moderation/sa-contrib-2018-067.yaml
+++ b/drupal/workbench_moderation/sa-contrib-2018-067.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-067'
+title: 'Workbench Moderation - Moderately critical - Access bypass - SA-CONTRIB-2018-067'
+branches:
+    1.4.x: { time: '2018-10-17 16:38:32', versions: ['>=1.0.0', '<1.4.0'] }
+composer-repository: 'https://packages.drupal.org/8'
+reference: 'composer://drupal/workbench_moderation'

--- a/drupal/workbench_moderation/sa-contrib-2018-067.yaml
+++ b/drupal/workbench_moderation/sa-contrib-2018-067.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-067'
 title: 'Workbench Moderation - Moderately critical - Access bypass - SA-CONTRIB-2018-067'
 branches:
-    1.4.x: { time: '2018-10-17 16:38:32', versions: ['>=1.0.0', '<1.4.0'] }
+    1.4.x:
+        time: '2018-10-17 17:13:21'
+        versions: ['>=1.0.0', '<1.4.0']
 composer-repository: 'https://packages.drupal.org/8'
 reference: 'composer://drupal/workbench_moderation'

--- a/drupal/yandex_metrics/sa-contrib-2017-78.yaml
+++ b/drupal/yandex_metrics/sa-contrib-2017-78.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2017-78'
 title: 'Yandex.Metrics - Moderately critical - Cross site scripting - SA-CONTRIB-2017-78'
 branches:
-    3.1.x: { time: '2017-10-18 16:38:31', versions: ['>=3.0.0', '<3.1.0'] }
+    3.1.x:
+        time: '2017-10-18 17:13:21'
+        versions: ['>=3.0.0', '<3.1.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/yandex_metrics'

--- a/drupal/yandex_metrics/sa-contrib-2017-78.yaml
+++ b/drupal/yandex_metrics/sa-contrib-2017-78.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2017-78'
+title: 'Yandex.Metrics - Moderately critical - Cross site scripting - SA-CONTRIB-2017-78'
+branches:
+    3.1.x: { time: '2017-10-18 16:38:31', versions: ['>=3.0.0', '<3.1.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/yandex_metrics'

--- a/drupal/zircon/sa-contrib-2018-037.yaml
+++ b/drupal/zircon/sa-contrib-2018-037.yaml
@@ -1,0 +1,6 @@
+link: 'https://www.drupal.org/sa-contrib-2018-037'
+title: 'Zircon - Critical - Unsupported - SA-CONTRIB-2018-037'
+branches:
+    1.2.x: { time: '2018-05-23 16:38:31', versions: ['>=1.0.0', '<1.2.0'] }
+composer-repository: 'https://packages.drupal.org/7'
+reference: 'composer://drupal/zircon'

--- a/drupal/zircon/sa-contrib-2018-037.yaml
+++ b/drupal/zircon/sa-contrib-2018-037.yaml
@@ -1,6 +1,8 @@
 link: 'https://www.drupal.org/sa-contrib-2018-037'
 title: 'Zircon - Critical - Unsupported - SA-CONTRIB-2018-037'
 branches:
-    1.2.x: { time: '2018-05-23 16:38:31', versions: ['>=1.0.0', '<1.2.0'] }
+    1.2.x:
+        time: '2018-05-23 17:13:21'
+        versions: ['>=1.0.0', '<1.2.0']
 composer-repository: 'https://packages.drupal.org/7'
 reference: 'composer://drupal/zircon'


### PR DESCRIPTION
Here is an initial dump of Drupal contrib SA.

This fixes #366

I will clean up the script and publish as its own when I get the time.

Edit: Just to clarify: I made the script to parse the latest advisories published. It could theoretically go back in history more, but the format changed some time in 2017. So instead of trying to add parse exceptions, I am going to assume that people with projects not updated for a couple of years, in spite advisories, would not use this repo and its tooling anyway. Open to comments and suggestions on that :)