### PR TITLE
Add advisory for Parsedown

### DIFF
--- a/erusev/parsedown/2019-03-17-1.yaml
+++ b/erusev/parsedown/2019-03-17-1.yaml
@@ -1,0 +1,7 @@
+title:     Class-Name Injection 
+link:      https://github.com/erusev/parsedown/issues/699
+branches:
+    1.x:
+        time:     ~
+        versions: ['<1.7.2']
+reference: composer://erusev/parsedown

--- a/erusev/parsedown/CVE-2019-10905.yaml
+++ b/erusev/parsedown/CVE-2019-10905.yaml
@@ -1,5 +1,6 @@
 title:     Class-Name Injection 
 link:      https://github.com/erusev/parsedown/issues/699
+cve:       CVE-2019-10905
 branches:
     1.x:
         time:     ~


### PR DESCRIPTION
In https://github.com/erusev/parsedown/issues/699 @xPaw pointed out that arbitrary class names can be attached to fenced code blocks. This constitutes a trust boundary violation, where the expected behaviour is that output from the parser would only allow users to attach a class name that had a `language-` prefix.

The exact implications of this are context dependent, but could allow an attacker to abuse existing functionality on the page e.g. defacement by attaching classes with defined CSS styling, or if there happened to be a script on the page looking for and interacting with elements that had a specific class (at worst, perhaps some kind of `execute-me` class could be attached where the contents of the element would then be executed).

This issue was resolved in 1.7.2 with https://github.com/erusev/parsedown/commit/bc003952fcbed63be7489e19e4a2710ae978866e.