### PR TITLE
[TASK] Add security advisories for TYPO3's May 2019 releases

### DIFF
--- a/typo3/cms-core/2019-05-07-1.yaml
+++ b/typo3/cms-core/2019-05-07-1.yaml
@@ -1,0 +1,10 @@
+title: 'Cross-Site Scripting in Fluid Engine'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-013/'
+branches:
+    8.x:
+        time: '2019-05-07 09:34:18'
+        versions: ['>=8.0.0', '<8.7.25']
+    9.x:
+        time: '2019-05-07 09:33:52'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/2019-05-07-2.yaml
+++ b/typo3/cms-core/2019-05-07-2.yaml
@@ -1,0 +1,10 @@
+title: 'Security Misconfiguration in User Session Handling'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-011/'
+branches:
+    8.x:
+        time: '2019-05-07 09:42:07'
+        versions: ['>=8.0.0', '<8.7.25']
+    9.x:
+        time: '2019-05-07 09:43:18'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/2019-05-07-3.yaml
+++ b/typo3/cms-core/2019-05-07-3.yaml
@@ -1,0 +1,10 @@
+title: 'Possible Arbitrary Code Execution in Image Processing'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-012/'
+branches:
+    8.x:
+        time: '2019-05-07 09:42:26'
+        versions: ['>=8.0.0', '<8.7.25']
+    9.x:
+        time: '2019-05-07 09:43:36'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/2019-05-07-4.yaml
+++ b/typo3/cms-core/2019-05-07-4.yaml
@@ -1,0 +1,7 @@
+title: 'Information Disclosure in Page Tree'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-009/'
+branches:
+    9.x:
+        time: '2019-05-07 09:42:43'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/2019-05-07-5.yaml
+++ b/typo3/cms-core/2019-05-07-5.yaml
@@ -1,0 +1,7 @@
+title: 'Information Disclosure in User Authentication'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-010/'
+branches:
+    9.x:
+        time: '2019-05-07 09:43:01'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms/2019-05-07-1.yaml
+++ b/typo3/cms/2019-05-07-1.yaml
@@ -1,0 +1,10 @@
+title: 'Cross-Site Scripting in Fluid Engine'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-013/'
+branches:
+    8.x:
+        time: '2019-05-07 09:34:18'
+        versions: ['>=8.0.0', '<8.7.25']
+    9.x:
+        time: '2019-05-07 09:33:52'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms'

--- a/typo3/cms/2019-05-07-2.yaml
+++ b/typo3/cms/2019-05-07-2.yaml
@@ -1,0 +1,10 @@
+title: 'Security Misconfiguration in User Session Handling'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-011/'
+branches:
+    8.x:
+        time: '2019-05-07 09:42:07'
+        versions: ['>=8.0.0', '<8.7.25']
+    9.x:
+        time: '2019-05-07 09:43:18'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms'

--- a/typo3/cms/2019-05-07-3.yaml
+++ b/typo3/cms/2019-05-07-3.yaml
@@ -1,0 +1,10 @@
+title: 'Possible Arbitrary Code Execution in Image Processing'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-012/'
+branches:
+    8.x:
+        time: '2019-05-07 09:42:26'
+        versions: ['>=8.0.0', '<8.7.25']
+    9.x:
+        time: '2019-05-07 09:43:36'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms'

--- a/typo3/cms/2019-05-07-4.yaml
+++ b/typo3/cms/2019-05-07-4.yaml
@@ -1,0 +1,7 @@
+title: 'Information Disclosure in Page Tree'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-009/'
+branches:
+    9.x:
+        time: '2019-05-07 09:42:43'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms'

--- a/typo3/cms/2019-05-07-5.yaml
+++ b/typo3/cms/2019-05-07-5.yaml
@@ -1,0 +1,7 @@
+title: 'Information Disclosure in User Authentication'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2019-010/'
+branches:
+    9.x:
+        time: '2019-05-07 09:43:01'
+        versions: ['>=9.0.0', '<9.5.6']
+reference: 'composer://typo3/cms'


### PR DESCRIPTION
+ autogenerated by https://github.com/TYPO3/darth
+ `bin/darth security 8.7.25,9.5.6`