### PR TITLE
Sylius, CVE-2019-12186: XSS injection in the Grid component

### DIFF
--- a/sylius/grid-bundle/CVE-2019-12186.yaml
+++ b/sylius/grid-bundle/CVE-2019-12186.yaml
@@ -1,0 +1,23 @@
+title: "CVE-2019-12186: XSS injection in the Grid component"
+link: https://sylius.com/blog/cve-2019-12186/
+cve: CVE-2019-12186
+branches:
+    1.0.x:
+        time: ~
+        versions: ['>=1.0.0', '<1.1.0']
+    1.1.x:
+        time: 2019-05-21 21:55:02 +0800
+        versions: ['>=1.1.0', '<1.1.19']
+    1.2.x:
+        time: 2019-05-21 21:57:22 +0800
+        versions: ['>=1.2.0', '<1.2.18']
+    1.3.x:
+        time: 2019-05-21 21:58:28 +0800
+        versions: ['>=1.3.0', '<1.3.13']
+    1.4.x:
+        time: 2019-05-21 21:59:30 +0800
+        versions: ['>=1.4.0', '<1.4.5']
+    1.5.x:
+        time: 2019-05-21 22:01:24 +0800
+        versions: ['>=1.5.0', '<1.5.1']
+reference: composer://sylius/grid-bundle

--- a/sylius/grid/CVE-2019-12186.yaml
+++ b/sylius/grid/CVE-2019-12186.yaml
@@ -1,0 +1,23 @@
+title: "CVE-2019-12186: XSS injection in the Grid component"
+link: https://sylius.com/blog/cve-2019-12186/
+cve: CVE-2019-12186
+branches:
+    1.0.x:
+        time: ~
+        versions: ['>=1.0.0', '<1.1.0']
+    1.1.x:
+        time: 2019-05-21 21:55:02 +0800
+        versions: ['>=1.1.0', '<1.1.19']
+    1.2.x:
+        time: 2019-05-21 21:57:22 +0800
+        versions: ['>=1.2.0', '<1.2.18']
+    1.3.x:
+        time: 2019-05-21 21:58:28 +0800
+        versions: ['>=1.3.0', '<1.3.13']
+    1.4.x:
+        time: 2019-05-21 21:59:30 +0800
+        versions: ['>=1.4.0', '<1.4.5']
+    1.5.x:
+        time: 2019-05-21 22:01:24 +0800
+        versions: ['>=1.5.0', '<1.5.1']
+reference: composer://sylius/grid

--- a/sylius/sylius/CVE-2019-12186.yaml
+++ b/sylius/sylius/CVE-2019-12186.yaml
@@ -1,0 +1,20 @@
+title: "CVE-2019-12186: XSS injection in the Grid component"
+link: https://sylius.com/blog/cve-2019-12186/
+cve: CVE-2019-12186
+branches:
+    1.0.x:
+        time: ~
+        versions: ['>=1.0.0', '<1.1.0']
+    1.1.x:
+        time: ~
+        versions: ['>=1.1.0', '<1.1.18']
+    1.2.x:
+        time: ~
+        versions: ['>=1.2.0', '<1.2.17']
+    1.3.x:
+        time: ~
+        versions: ['>=1.3.0', '<1.3.12']
+    1.4.x:
+        time: ~
+        versions: ['>=1.4.0', '<1.4.4']
+reference: composer://sylius/sylius


### PR DESCRIPTION
Three packages affected:

`sylius/sylius` used to replace `sylius/grid` and `sylius/grid-bundle`
`sylius/grid-bundle` used to be standalone, now also replaces `sylius/grid`