### PR TITLE
add Drupal core - Critical - Access bypass - SA-CORE-2019-008

### DIFF
--- a/drupal/core/CVE-2019-6342.yaml
+++ b/drupal/core/CVE-2019-6342.yaml
@@ -1,0 +1,8 @@
+title: Critical - Access bypass
+link: https://www.drupal.org/sa-core-2019-008
+cve: CVE-2019-6342
+branches:
+    8.7.x:
+        time:     2019-07-16 16:24:00
+        versions: ['>8.7.3','<8.7.5']
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2019-6342.yaml
+++ b/drupal/drupal/CVE-2019-6342.yaml
@@ -1,0 +1,8 @@
+title: Critical - Access bypass
+link: https://www.drupal.org/sa-core-2019-008
+cve: CVE-2019-6342
+branches:
+    8.7.x:
+        time:     2019-07-16 16:24:00
+        versions: ['>8.7.3','<8.7.5']
+reference: composer://drupal/drupal


### PR DESCRIPTION
Just a single version (`8.7.4`) is affected, but I have to define a range with an upper boundary (defined with `<`). More: https://github.com/FriendsOfPHP/security-advisories/issues/408