### PR TITLE
Magento 2.1.18, 2.2.9 and 2.3.2

### DIFF
--- a/magento/magento1ce/CVE-2019-7849.yaml
+++ b/magento/magento1ce/CVE-2019-7849.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2095: Defense-in-depth session validation check implemented'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7849
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7849.yaml
+++ b/magento/magento1ce/CVE-2019-7849.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2095: Defense-in-depth session validation check implemented'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7849
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7875.yaml
+++ b/magento/magento1ce/CVE-2019-7875.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2226: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7875
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7875.yaml
+++ b/magento/magento1ce/CVE-2019-7875.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2226: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7875
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7882.yaml
+++ b/magento/magento1ce/CVE-2019-7882.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2246: Stored cross-site scripting in the WYSIWYG editor'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7882
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7882.yaml
+++ b/magento/magento1ce/CVE-2019-7882.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2246: Stored cross-site scripting in the WYSIWYG editor'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7882
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7887.yaml
+++ b/magento/magento1ce/CVE-2019-7887.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2270: Reflected cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7887
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7887.yaml
+++ b/magento/magento1ce/CVE-2019-7887.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2270: Reflected cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7887
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7889.yaml
+++ b/magento/magento1ce/CVE-2019-7889.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2275: Unsafe functionality is exposed via email templates manipulation'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7889
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7889.yaml
+++ b/magento/magento1ce/CVE-2019-7889.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2275: Unsafe functionality is exposed via email templates manipulation'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7889
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7897.yaml
+++ b/magento/magento1ce/CVE-2019-7897.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2299: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7897
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7897.yaml
+++ b/magento/magento1ce/CVE-2019-7897.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2299: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7897
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7898.yaml
+++ b/magento/magento1ce/CVE-2019-7898.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2300: Information about  disabled products can be leaked due to inadequate validation checks'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7898
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7898.yaml
+++ b/magento/magento1ce/CVE-2019-7898.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2300: Information about  disabled products can be leaked due to inadequate validation checks'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7898
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7899.yaml
+++ b/magento/magento1ce/CVE-2019-7899.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2301: Names of disabled products can be leaked due to inadequate validation checks'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7899
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7899.yaml
+++ b/magento/magento1ce/CVE-2019-7899.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2301: Names of disabled products can be leaked due to inadequate validation checks'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7899
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7909.yaml
+++ b/magento/magento1ce/CVE-2019-7909.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2317: Stored cross-site scripting  in admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7909
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7909.yaml
+++ b/magento/magento1ce/CVE-2019-7909.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2317: Stored cross-site scripting  in admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7909
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7911.yaml
+++ b/magento/magento1ce/CVE-2019-7911.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2320: Arbitrary code execution due to unsafe handling of system configuration'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7911
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7911.yaml
+++ b/magento/magento1ce/CVE-2019-7911.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2320: Arbitrary code execution due to unsafe handling of system configuration'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7911
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7932.yaml
+++ b/magento/magento1ce/CVE-2019-7932.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2351: Arbitrary code execution via crafted sitemap creation'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7932
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7932.yaml
+++ b/magento/magento1ce/CVE-2019-7932.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2351: Arbitrary code execution via crafted sitemap creation'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7932
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7934.yaml
+++ b/magento/magento1ce/CVE-2019-7934.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2353: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7934
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7934.yaml
+++ b/magento/magento1ce/CVE-2019-7934.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2353: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7934
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7935.yaml
+++ b/magento/magento1ce/CVE-2019-7935.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2363: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7935
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7935.yaml
+++ b/magento/magento1ce/CVE-2019-7935.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2363: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7935
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7938.yaml
+++ b/magento/magento1ce/CVE-2019-7938.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2369: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7938
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7938.yaml
+++ b/magento/magento1ce/CVE-2019-7938.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2369: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7938
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7940.yaml
+++ b/magento/magento1ce/CVE-2019-7940.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2371: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7940
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7940.yaml
+++ b/magento/magento1ce/CVE-2019-7940.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2371: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7940
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7944.yaml
+++ b/magento/magento1ce/CVE-2019-7944.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2378: Stored cross-site scripting in the Return Product comments feature'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7944
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7944.yaml
+++ b/magento/magento1ce/CVE-2019-7944.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2378: Stored cross-site scripting in the Return Product comments feature'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7944
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7945.yaml
+++ b/magento/magento1ce/CVE-2019-7945.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2380: Stored cross-site scripting in the Currency Symbols field'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7945
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ce/CVE-2019-7945.yaml
+++ b/magento/magento1ce/CVE-2019-7945.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2380: Stored cross-site scripting in the Currency Symbols field'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7945
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7947.yaml
+++ b/magento/magento1ce/CVE-2019-7947.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2387: Cross site request forgery attacks are possible via the gift card removal feature'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7947
+reference: 'composer://magento/magento1ce'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.9.4.2']

--- a/magento/magento1ce/CVE-2019-7947.yaml
+++ b/magento/magento1ce/CVE-2019-7947.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2387: Cross site request forgery attacks are possible via the gift card removal feature'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7947
-reference: 'composer://magento/magento1ce'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.9.4.2']
+reference: 'composer://magento/magento1ce'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7849.yaml
+++ b/magento/magento1ee/CVE-2019-7849.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2095: Defense-in-depth session validation check implemented'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7849
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7849.yaml
+++ b/magento/magento1ee/CVE-2019-7849.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2095: Defense-in-depth session validation check implemented'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7849
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7875.yaml
+++ b/magento/magento1ee/CVE-2019-7875.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2226: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7875
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7875.yaml
+++ b/magento/magento1ee/CVE-2019-7875.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2226: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7875
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7882.yaml
+++ b/magento/magento1ee/CVE-2019-7882.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2246: Stored cross-site scripting in the WYSIWYG editor'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7882
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7882.yaml
+++ b/magento/magento1ee/CVE-2019-7882.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2246: Stored cross-site scripting in the WYSIWYG editor'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7882
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7887.yaml
+++ b/magento/magento1ee/CVE-2019-7887.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2270: Reflected cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7887
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7887.yaml
+++ b/magento/magento1ee/CVE-2019-7887.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2270: Reflected cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7887
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7889.yaml
+++ b/magento/magento1ee/CVE-2019-7889.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2275: Unsafe functionality is exposed via email templates manipulation'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7889
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7889.yaml
+++ b/magento/magento1ee/CVE-2019-7889.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2275: Unsafe functionality is exposed via email templates manipulation'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7889
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7897.yaml
+++ b/magento/magento1ee/CVE-2019-7897.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2299: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7897
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7897.yaml
+++ b/magento/magento1ee/CVE-2019-7897.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2299: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7897
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7898.yaml
+++ b/magento/magento1ee/CVE-2019-7898.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2300: Information about  disabled products can be leaked due to inadequate validation checks'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7898
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7898.yaml
+++ b/magento/magento1ee/CVE-2019-7898.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2300: Information about  disabled products can be leaked due to inadequate validation checks'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7898
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7899.yaml
+++ b/magento/magento1ee/CVE-2019-7899.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2301: Names of disabled products can be leaked due to inadequate validation checks'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7899
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7899.yaml
+++ b/magento/magento1ee/CVE-2019-7899.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2301: Names of disabled products can be leaked due to inadequate validation checks'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7899
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7909.yaml
+++ b/magento/magento1ee/CVE-2019-7909.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2317: Stored cross-site scripting  in admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7909
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7909.yaml
+++ b/magento/magento1ee/CVE-2019-7909.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2317: Stored cross-site scripting  in admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7909
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7911.yaml
+++ b/magento/magento1ee/CVE-2019-7911.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2320: Arbitrary code execution due to unsafe handling of system configuration'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7911
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7911.yaml
+++ b/magento/magento1ee/CVE-2019-7911.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2320: Arbitrary code execution due to unsafe handling of system configuration'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7911
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7932.yaml
+++ b/magento/magento1ee/CVE-2019-7932.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2351: Arbitrary code execution via crafted sitemap creation'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7932
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7932.yaml
+++ b/magento/magento1ee/CVE-2019-7932.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2351: Arbitrary code execution via crafted sitemap creation'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7932
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7934.yaml
+++ b/magento/magento1ee/CVE-2019-7934.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2353: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7934
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7934.yaml
+++ b/magento/magento1ee/CVE-2019-7934.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2353: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7934
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7935.yaml
+++ b/magento/magento1ee/CVE-2019-7935.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2363: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7935
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7935.yaml
+++ b/magento/magento1ee/CVE-2019-7935.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2363: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7935
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7938.yaml
+++ b/magento/magento1ee/CVE-2019-7938.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2369: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7938
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7938.yaml
+++ b/magento/magento1ee/CVE-2019-7938.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2369: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7938
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7940.yaml
+++ b/magento/magento1ee/CVE-2019-7940.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2371: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7940
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7940.yaml
+++ b/magento/magento1ee/CVE-2019-7940.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2371: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7940
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7944.yaml
+++ b/magento/magento1ee/CVE-2019-7944.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2378: Stored cross-site scripting in the Return Product comments feature'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7944
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7944.yaml
+++ b/magento/magento1ee/CVE-2019-7944.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2378: Stored cross-site scripting in the Return Product comments feature'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7944
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7945.yaml
+++ b/magento/magento1ee/CVE-2019-7945.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2380: Stored cross-site scripting in the Currency Symbols field'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7945
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/magento1ee/CVE-2019-7945.yaml
+++ b/magento/magento1ee/CVE-2019-7945.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2380: Stored cross-site scripting in the Currency Symbols field'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7945
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7947.yaml
+++ b/magento/magento1ee/CVE-2019-7947.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2387: Cross site request forgery attacks are possible via the gift card removal feature'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7947
-reference: 'composer://magento/magento1ee'
-composer-repository: false
 branches:
     1:
         time: '2019-06-25 00:00:00'
         versions: ['>=1', '<1.14.4.2']
+reference: 'composer://magento/magento1ee'
+composer-repository: false

--- a/magento/magento1ee/CVE-2019-7947.yaml
+++ b/magento/magento1ee/CVE-2019-7947.yaml
@@ -1,0 +1,9 @@
+title: 'PRODSECBUG-2387: Cross site request forgery attacks are possible via the gift card removal feature'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7947
+reference: 'composer://magento/magento1ee'
+composer-repository: false
+branches:
+    1:
+        time: '2019-06-25 00:00:00'
+        versions: ['>=1', '<1.14.4.2']

--- a/magento/product-community-edition/CVE-2019-7139.yaml
+++ b/magento/product-community-edition/CVE-2019-7139.yaml
@@ -1,9 +1,9 @@
 title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7139
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7846.yaml
+++ b/magento/product-community-edition/CVE-2019-7846.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-1513: Insufficient brute force protections on promo code entry'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7846
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7846.yaml
+++ b/magento/product-community-edition/CVE-2019-7846.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-1513: Insufficient brute force protections on promo code entry'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7846
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7849.yaml
+++ b/magento/product-community-edition/CVE-2019-7849.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2095: Defense-in-depth session validation check implemented'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7849
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7849.yaml
+++ b/magento/product-community-edition/CVE-2019-7849.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2095: Defense-in-depth session validation check implemented'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7849
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7850.yaml
+++ b/magento/product-community-edition/CVE-2019-7850.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2116: Stored cross-site scripting in the catalog events feature'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7850
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7850.yaml
+++ b/magento/product-community-edition/CVE-2019-7850.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2116: Stored cross-site scripting in the catalog events feature'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7850
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7851.yaml
+++ b/magento/product-community-edition/CVE-2019-7851.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2125: Deletion of Blocks via cross-site request forgery (CSRF)'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7851
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7851.yaml
+++ b/magento/product-community-edition/CVE-2019-7851.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2125: Deletion of Blocks via cross-site request forgery (CSRF)'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7851
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7852.yaml
+++ b/magento/product-community-edition/CVE-2019-7852.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2127: Disclosure of Magento admin panel URL'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7852
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7852.yaml
+++ b/magento/product-community-edition/CVE-2019-7852.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2127: Disclosure of Magento admin panel URL'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7852
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7853.yaml
+++ b/magento/product-community-edition/CVE-2019-7853.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2128: Stored Cross Site Scripting in the Admin Panel through the tax/notification/info_url setting'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7853
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7853.yaml
+++ b/magento/product-community-edition/CVE-2019-7853.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2128: Stored Cross Site Scripting in the Admin Panel through the tax/notification/info_url setting'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7853
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7854.yaml
+++ b/magento/product-community-edition/CVE-2019-7854.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2132: Insecure Direct Object Reference (IDOR) vulnerability can expose sensitive company details'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7854
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7854.yaml
+++ b/magento/product-community-edition/CVE-2019-7854.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2132: Insecure Direct Object Reference (IDOR) vulnerability can expose sensitive company details'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7854
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7855.yaml
+++ b/magento/product-community-edition/CVE-2019-7855.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2164: Use of cryptographically weak PRNG to create gift card codes'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7855
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7855.yaml
+++ b/magento/product-community-edition/CVE-2019-7855.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2164: Use of cryptographically weak PRNG to create gift card codes'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7855
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7857.yaml
+++ b/magento/product-community-edition/CVE-2019-7857.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2171: Insecure token implementation leads to Cross-Site Request Forgery (CSRF)'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7857
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7857.yaml
+++ b/magento/product-community-edition/CVE-2019-7857.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2171: Insecure token implementation leads to Cross-Site Request Forgery (CSRF)'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7857
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7858.yaml
+++ b/magento/product-community-edition/CVE-2019-7858.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2172: Insecure user credential storage'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7858
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7858.yaml
+++ b/magento/product-community-edition/CVE-2019-7858.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2172: Insecure user credential storage'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7858
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7859.yaml
+++ b/magento/product-community-edition/CVE-2019-7859.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2173: Path traversal vulnerability in WYSIWYG editor.'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7859
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7859.yaml
+++ b/magento/product-community-edition/CVE-2019-7859.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2173: Path traversal vulnerability in WYSIWYG editor.'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7859
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7860.yaml
+++ b/magento/product-community-edition/CVE-2019-7860.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2174: Use of insufficiently random values in multiple security relevant contexts'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7860
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7860.yaml
+++ b/magento/product-community-edition/CVE-2019-7860.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2174: Use of insufficiently random values in multiple security relevant contexts'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7860
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7861.yaml
+++ b/magento/product-community-edition/CVE-2019-7861.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2177: Insufficient server side validations leads to Insecure File upload vulnerability'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7861
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7861.yaml
+++ b/magento/product-community-edition/CVE-2019-7861.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2177: Insufficient server side validations leads to Insecure File upload vulnerability'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7861
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7862.yaml
+++ b/magento/product-community-edition/CVE-2019-7862.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2182: Reflected cross-site scripting in the admin panel.'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7862
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7862.yaml
+++ b/magento/product-community-edition/CVE-2019-7862.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2182: Reflected cross-site scripting in the admin panel.'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7862
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7863.yaml
+++ b/magento/product-community-edition/CVE-2019-7863.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2183: Stored cross-site scripting in admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7863
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7863.yaml
+++ b/magento/product-community-edition/CVE-2019-7863.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2183: Stored cross-site scripting in admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7863
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7864.yaml
+++ b/magento/product-community-edition/CVE-2019-7864.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2186: Insecure Direct Object Reference (IDOR) vulnerability can expose order details'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7864
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7864.yaml
+++ b/magento/product-community-edition/CVE-2019-7864.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2186: Insecure Direct Object Reference (IDOR) vulnerability can expose order details'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7864
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7865.yaml
+++ b/magento/product-community-edition/CVE-2019-7865.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2187: Cross-site request forgery (CSRF) in checkout cart item'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7865
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7865.yaml
+++ b/magento/product-community-edition/CVE-2019-7865.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2187: Cross-site request forgery (CSRF) in checkout cart item'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7865
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7866.yaml
+++ b/magento/product-community-edition/CVE-2019-7866.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2188: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7866
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7866.yaml
+++ b/magento/product-community-edition/CVE-2019-7866.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2188: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7866
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7867.yaml
+++ b/magento/product-community-edition/CVE-2019-7867.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2190: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7867
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7867.yaml
+++ b/magento/product-community-edition/CVE-2019-7867.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2190: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7867
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7868.yaml
+++ b/magento/product-community-edition/CVE-2019-7868.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2193: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7868
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7868.yaml
+++ b/magento/product-community-edition/CVE-2019-7868.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2193: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7868
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7869.yaml
+++ b/magento/product-community-edition/CVE-2019-7869.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2194: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7869
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7869.yaml
+++ b/magento/product-community-edition/CVE-2019-7869.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2194: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7869
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7871.yaml
+++ b/magento/product-community-edition/CVE-2019-7871.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2202: Security bypass via form data injection'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7871
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7871.yaml
+++ b/magento/product-community-edition/CVE-2019-7871.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2202: Security bypass via form data injection'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7871
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7872.yaml
+++ b/magento/product-community-edition/CVE-2019-7872.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2208: Insufficient authorization check when adding users to company accounts'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7872
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7872.yaml
+++ b/magento/product-community-edition/CVE-2019-7872.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2208: Insufficient authorization check when adding users to company accounts'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7872
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7873.yaml
+++ b/magento/product-community-edition/CVE-2019-7873.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2220: Deletion of store design schedule via cross-site request forgery (CSRF)'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7873
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7873.yaml
+++ b/magento/product-community-edition/CVE-2019-7873.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2220: Deletion of store design schedule via cross-site request forgery (CSRF)'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7873
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7874.yaml
+++ b/magento/product-community-edition/CVE-2019-7874.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2222: Deletion of user roles via cross-site request forgery (CSRF)'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7874
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7874.yaml
+++ b/magento/product-community-edition/CVE-2019-7874.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2222: Deletion of user roles via cross-site request forgery (CSRF)'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7874
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7875.yaml
+++ b/magento/product-community-edition/CVE-2019-7875.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2226: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7875
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7875.yaml
+++ b/magento/product-community-edition/CVE-2019-7875.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2226: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7875
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7876.yaml
+++ b/magento/product-community-edition/CVE-2019-7876.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2232: Arbitrary code execution via layout manipulation'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7876
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7876.yaml
+++ b/magento/product-community-edition/CVE-2019-7876.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2232: Arbitrary code execution via layout manipulation'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7876
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7877.yaml
+++ b/magento/product-community-edition/CVE-2019-7877.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2233: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7877
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7877.yaml
+++ b/magento/product-community-edition/CVE-2019-7877.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2233: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7877
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7880.yaml
+++ b/magento/product-community-edition/CVE-2019-7880.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2244: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7880
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7880.yaml
+++ b/magento/product-community-edition/CVE-2019-7880.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2244: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7880
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7881.yaml
+++ b/magento/product-community-edition/CVE-2019-7881.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2245: Stored cross-site scripting in store shipping methods configuration'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7881
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7881.yaml
+++ b/magento/product-community-edition/CVE-2019-7881.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2245: Stored cross-site scripting in store shipping methods configuration'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7881
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7882.yaml
+++ b/magento/product-community-edition/CVE-2019-7882.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2246: Stored cross-site scripting in the WYSIWYG editor'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7882
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7882.yaml
+++ b/magento/product-community-edition/CVE-2019-7882.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2246: Stored cross-site scripting in the WYSIWYG editor'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7882
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7885.yaml
+++ b/magento/product-community-edition/CVE-2019-7885.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2266: Arbitrary code execution through malicious elastic search module configuration'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7885
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7885.yaml
+++ b/magento/product-community-edition/CVE-2019-7885.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2266: Arbitrary code execution through malicious elastic search module configuration'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7885
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7886.yaml
+++ b/magento/product-community-edition/CVE-2019-7886.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2267: Use of insufficiently random values when generating initialization vector'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7886
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7886.yaml
+++ b/magento/product-community-edition/CVE-2019-7886.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2267: Use of insufficiently random values when generating initialization vector'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7886
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7887.yaml
+++ b/magento/product-community-edition/CVE-2019-7887.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2270: Reflected cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7887
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7887.yaml
+++ b/magento/product-community-edition/CVE-2019-7887.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2270: Reflected cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7887
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7888.yaml
+++ b/magento/product-community-edition/CVE-2019-7888.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2273: Sensitive data disclosure though malicious email templates'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7888
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7888.yaml
+++ b/magento/product-community-edition/CVE-2019-7888.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2273: Sensitive data disclosure though malicious email templates'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7888
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7889.yaml
+++ b/magento/product-community-edition/CVE-2019-7889.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2275: Unsafe functionality is exposed via email templates manipulation'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7889
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7889.yaml
+++ b/magento/product-community-edition/CVE-2019-7889.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2275: Unsafe functionality is exposed via email templates manipulation'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7889
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7890.yaml
+++ b/magento/product-community-edition/CVE-2019-7890.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2276: Insecure Direct Object Reference (IDOR) vulnerability can expose order shipping details'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7890
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7890.yaml
+++ b/magento/product-community-edition/CVE-2019-7890.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2276: Insecure Direct Object Reference (IDOR) vulnerability can expose order shipping details'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7890
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7892.yaml
+++ b/magento/product-community-edition/CVE-2019-7892.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2285: Arbitrary code execution due to unsafe handling of  a carrier gateway'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7892
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7892.yaml
+++ b/magento/product-community-edition/CVE-2019-7892.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2285: Arbitrary code execution due to unsafe handling of  a carrier gateway'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7892
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7895.yaml
+++ b/magento/product-community-edition/CVE-2019-7895.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2296: Arbitrary code execution through design layout update'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7895
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7895.yaml
+++ b/magento/product-community-edition/CVE-2019-7895.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2296: Arbitrary code execution through design layout update'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7895
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7896.yaml
+++ b/magento/product-community-edition/CVE-2019-7896.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2298: Arbitrary code execution through product imports and design layout update'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7896
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7896.yaml
+++ b/magento/product-community-edition/CVE-2019-7896.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2298: Arbitrary code execution through product imports and design layout update'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7896
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7897.yaml
+++ b/magento/product-community-edition/CVE-2019-7897.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2299: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7897
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7897.yaml
+++ b/magento/product-community-edition/CVE-2019-7897.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2299: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7897
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7898.yaml
+++ b/magento/product-community-edition/CVE-2019-7898.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2300: Information about  disabled products can be leaked due to inadequate validation checks'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7898
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7898.yaml
+++ b/magento/product-community-edition/CVE-2019-7898.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2300: Information about  disabled products can be leaked due to inadequate validation checks'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7898
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7899.yaml
+++ b/magento/product-community-edition/CVE-2019-7899.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2301: Names of disabled products can be leaked due to inadequate validation checks'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7899
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7899.yaml
+++ b/magento/product-community-edition/CVE-2019-7899.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2301: Names of disabled products can be leaked due to inadequate validation checks'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7899
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7903.yaml
+++ b/magento/product-community-edition/CVE-2019-7903.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2306: Remote code execution through crafted email templates'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7903
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7903.yaml
+++ b/magento/product-community-edition/CVE-2019-7903.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2306: Remote code execution through crafted email templates'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7903
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7904.yaml
+++ b/magento/product-community-edition/CVE-2019-7904.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2307: Insufficient enforcement of user access controls can lead to unauthorized environment configuration changes'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7904
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7904.yaml
+++ b/magento/product-community-edition/CVE-2019-7904.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2307: Insufficient enforcement of user access controls can lead to unauthorized environment configuration changes'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7904
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7908.yaml
+++ b/magento/product-community-edition/CVE-2019-7908.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2316: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7908
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7908.yaml
+++ b/magento/product-community-edition/CVE-2019-7908.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2316: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7908
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7909.yaml
+++ b/magento/product-community-edition/CVE-2019-7909.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2317: Stored cross-site scripting  in admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7909
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7909.yaml
+++ b/magento/product-community-edition/CVE-2019-7909.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2317: Stored cross-site scripting  in admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7909
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7911.yaml
+++ b/magento/product-community-edition/CVE-2019-7911.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2320: Arbitrary code execution due to unsafe handling of system configuration'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7911
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7911.yaml
+++ b/magento/product-community-edition/CVE-2019-7911.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2320: Arbitrary code execution due to unsafe handling of system configuration'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7911
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7912.yaml
+++ b/magento/product-community-edition/CVE-2019-7912.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2321: Filter extension bypass via crafted store configuration keys'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7912
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7912.yaml
+++ b/magento/product-community-edition/CVE-2019-7912.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2321: Filter extension bypass via crafted store configuration keys'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7912
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7913.yaml
+++ b/magento/product-community-edition/CVE-2019-7913.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2322: Arbitrary code execution due to unsafe handling of  a shipping gateway'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7913
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7913.yaml
+++ b/magento/product-community-edition/CVE-2019-7913.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2322: Arbitrary code execution due to unsafe handling of  a shipping gateway'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7913
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7915.yaml
+++ b/magento/product-community-edition/CVE-2019-7915.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2325: Denial-of-service by forcing a store to respond with a 404 error'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7915
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7915.yaml
+++ b/magento/product-community-edition/CVE-2019-7915.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2325: Denial-of-service by forcing a store to respond with a 404 error'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7915
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7921.yaml
+++ b/magento/product-community-edition/CVE-2019-7921.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2337: Stored cross-site scripting in the catalog templates form'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7921
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7921.yaml
+++ b/magento/product-community-edition/CVE-2019-7921.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2337: Stored cross-site scripting in the catalog templates form'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7921
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7923.yaml
+++ b/magento/product-community-edition/CVE-2019-7923.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2339: Arbitrary code execution due to unsafe handling of  a carrier gateway'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7923
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7923.yaml
+++ b/magento/product-community-edition/CVE-2019-7923.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2339: Arbitrary code execution due to unsafe handling of  a carrier gateway'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7923
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7925.yaml
+++ b/magento/product-community-edition/CVE-2019-7925.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2343: Insecure Direct Object Reference (IDOR) vulnerability can lead to deletion of downloadable products folder'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7925
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7925.yaml
+++ b/magento/product-community-edition/CVE-2019-7925.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2343: Insecure Direct Object Reference (IDOR) vulnerability can lead to deletion of downloadable products folder'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7925
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7926.yaml
+++ b/magento/product-community-edition/CVE-2019-7926.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2345: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7926
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7926.yaml
+++ b/magento/product-community-edition/CVE-2019-7926.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2345: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7926
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7927.yaml
+++ b/magento/product-community-edition/CVE-2019-7927.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2346: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7927
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7927.yaml
+++ b/magento/product-community-edition/CVE-2019-7927.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2346: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7927
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7928.yaml
+++ b/magento/product-community-edition/CVE-2019-7928.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2347: Insufficient brute-forcing defenses in the token exchange protocol could be abused in carding attacks'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7928
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7928.yaml
+++ b/magento/product-community-edition/CVE-2019-7928.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2347: Insufficient brute-forcing defenses in the token exchange protocol could be abused in carding attacks'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7928
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7929.yaml
+++ b/magento/product-community-edition/CVE-2019-7929.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2348: Sensitive data disclosure via crafted two factor edit user form'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7929
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7929.yaml
+++ b/magento/product-community-edition/CVE-2019-7929.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2348: Sensitive data disclosure via crafted two factor edit user form'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7929
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7930.yaml
+++ b/magento/product-community-edition/CVE-2019-7930.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2349: Arbitrary code execution via file upload in admin import feature'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
+cve: CVE-2019-7930
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7930.yaml
+++ b/magento/product-community-edition/CVE-2019-7930.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2349: Arbitrary code execution via file upload in admin import feature'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7930
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7932.yaml
+++ b/magento/product-community-edition/CVE-2019-7932.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2351: Arbitrary code execution via crafted sitemap creation'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7932
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7932.yaml
+++ b/magento/product-community-edition/CVE-2019-7932.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2351: Arbitrary code execution via crafted sitemap creation'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7932
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7934.yaml
+++ b/magento/product-community-edition/CVE-2019-7934.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2353: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7934
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7934.yaml
+++ b/magento/product-community-edition/CVE-2019-7934.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2353: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7934
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7935.yaml
+++ b/magento/product-community-edition/CVE-2019-7935.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2363: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7935
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7935.yaml
+++ b/magento/product-community-edition/CVE-2019-7935.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2363: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7935
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7936.yaml
+++ b/magento/product-community-edition/CVE-2019-7936.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2364: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7936
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7936.yaml
+++ b/magento/product-community-edition/CVE-2019-7936.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2364: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7936
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7937.yaml
+++ b/magento/product-community-edition/CVE-2019-7937.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2366: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7937
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7937.yaml
+++ b/magento/product-community-edition/CVE-2019-7937.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2366: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7937
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7938.yaml
+++ b/magento/product-community-edition/CVE-2019-7938.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2369: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7938
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7938.yaml
+++ b/magento/product-community-edition/CVE-2019-7938.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2369: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7938
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7939.yaml
+++ b/magento/product-community-edition/CVE-2019-7939.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2370: Reflected cross-site scripting on customer cart page'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7939
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7939.yaml
+++ b/magento/product-community-edition/CVE-2019-7939.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2370: Reflected cross-site scripting on customer cart page'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7939
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7940.yaml
+++ b/magento/product-community-edition/CVE-2019-7940.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2371: Stored cross-site scripting in the admin panel'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7940
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7940.yaml
+++ b/magento/product-community-edition/CVE-2019-7940.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2371: Stored cross-site scripting in the admin panel'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7940
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7942.yaml
+++ b/magento/product-community-edition/CVE-2019-7942.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2375: Arbitrary code execution via malicious XML layouts'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7942
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7942.yaml
+++ b/magento/product-community-edition/CVE-2019-7942.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2375: Arbitrary code execution via malicious XML layouts'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7942
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7944.yaml
+++ b/magento/product-community-edition/CVE-2019-7944.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2378: Stored cross-site scripting in the Return Product comments feature'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7944
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7944.yaml
+++ b/magento/product-community-edition/CVE-2019-7944.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2378: Stored cross-site scripting in the Return Product comments feature'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7944
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7945.yaml
+++ b/magento/product-community-edition/CVE-2019-7945.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2380: Stored cross-site scripting in the Currency Symbols field'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
 cve: CVE-2019-7945
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7945.yaml
+++ b/magento/product-community-edition/CVE-2019-7945.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2380: Stored cross-site scripting in the Currency Symbols field'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-23'
+cve: CVE-2019-7945
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7947.yaml
+++ b/magento/product-community-edition/CVE-2019-7947.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2387: Cross site request forgery attacks are possible via the gift card removal feature'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
 cve: CVE-2019-7947
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7947.yaml
+++ b/magento/product-community-edition/CVE-2019-7947.yaml
@@ -1,0 +1,15 @@
+title: 'PRODSECBUG-2387: Cross site request forgery attacks are possible via the gift card removal feature'
+link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-33'
+cve: CVE-2019-7947
+reference: 'composer://magento/product-community-edition'
+composer-repository: false
+branches:
+    '2.1':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7950.yaml
+++ b/magento/product-community-edition/CVE-2019-7950.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2429: Insecure object reference via customer REST API'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7950
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7950.yaml
+++ b/magento/product-community-edition/CVE-2019-7950.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2429: Insecure object reference via customer REST API'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7950
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']

--- a/magento/product-community-edition/CVE-2019-7951.yaml
+++ b/magento/product-community-edition/CVE-2019-7951.yaml
@@ -1,8 +1,6 @@
 title: 'PRODSECBUG-2430: Security bypass via crafted SOAP requests'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
 cve: CVE-2019-7951
-reference: 'composer://magento/product-community-edition'
-composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
@@ -13,3 +11,5 @@ branches:
     '2.3':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.3', '<2.3.2']
+reference: 'composer://magento/product-community-edition'
+composer-repository: false

--- a/magento/product-community-edition/CVE-2019-7951.yaml
+++ b/magento/product-community-edition/CVE-2019-7951.yaml
@@ -1,9 +1,15 @@
-title: 'PRODSECBUG-2198: SQL Injection due to a flaw in MySQL adapter'
+title: 'PRODSECBUG-2430: Security bypass via crafted SOAP requests'
 link: 'https://magento.com/security/patches/magento-2.3.2-2.2.9-and-2.1.18-security-update-13'
-cve: CVE-2019-7139
+cve: CVE-2019-7951
 reference: 'composer://magento/product-community-edition'
 composer-repository: false
 branches:
     '2.1':
         time: '2019-06-25 00:00:00'
         versions: ['>=2.1', '<2.1.18']
+    '2.2':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.2', '<2.2.9']
+    '2.3':
+        time: '2019-06-25 00:00:00'
+        versions: ['>=2.3', '<2.3.2']


### PR DESCRIPTION
A bit outdated since newer versions are released already, but it will at least keep track of the CVE numbers here