### PR TITLE
Corrects the vulnerable version of PHP Excel

### DIFF
--- a/phpoffice/phpexcel/CVE-2018-19277.yaml
+++ b/phpoffice/phpexcel/CVE-2018-19277.yaml
@@ -4,5 +4,5 @@ cve:       CVE-2018-19277
 branches:
     master:
         time:       2018-11-22 23:07:00
-        versions:   ['<=1.8.1']
+        versions:   ['<=1.8.2']
 reference: composer://phpoffice/phpexcel


### PR DESCRIPTION
The PHP Excel project released another version which basically archived the project but importantly didn't fix this vulnerability.

Changes in the 1.8.2 release: https://github.com/PHPOffice/PHPExcel/compare/1.8.2...1.8