### PR TITLE
Add link to security advisory

### DIFF
--- a/robrichards/xmlseclibs/CVE-2019-3465.yaml
+++ b/robrichards/xmlseclibs/CVE-2019-3465.yaml
@@ -1,5 +1,5 @@
 title:     Critical signature bypass
-link:      https://github.com/robrichards/xmlseclibs/commit/0a53d3c3aa87564910cae4ed01416441d3ae0db5
+link:      https://simplesamlphp.org/security/201911-01
 cve:       CVE-2019-3465
 branches:
     1.x:


### PR DESCRIPTION
The security advisory regarding this issue is published in the given URL.