### PR TITLE
Add a validator ensuring that each branch has a well-formed range

### DIFF
--- a/validator.php
+++ b/validator.php
@@ -179,10 +179,20 @@ final class Validate extends Command
                             }
 
                             if ('<' === substr($version, 0, 1)) {
+                                if (null !== $upperBound) {
+                                    $messages[$path][] = sprintf('"versions" cannot have multiple upper bounds for branch "%s".', $name);
+                                    continue;
+                                }
+
                                 $upperBound = $version;
                                 continue;
                             }
                             if ('>' === substr($version, 0, 1)) {
+                                if ($hasMin) {
+                                    $messages[$path][] = sprintf('"versions" cannot have multiple lower bounds for branch "%s".', $name);
+                                    continue;
+                                }
+
                                 $hasMin = true;
                             }
                         }


### PR DESCRIPTION
It does not make sense to have multiple upper bounds for a range, as they would need to match all, meaning that the lowest version of them would be the useful one. Same is true for lower bounds (except that the highest version is the meaningful one).
Defining multiple affected ranges is what branches are representing in the advisory format.

Build will be green once #425 is merged