### PR TITLE
Add security advisories for scheb/two-factor-bundle

### DIFF
--- a/scheb/two-factor-bundle/2018-07-08.yaml
+++ b/scheb/two-factor-bundle/2018-07-08.yaml
@@ -1,0 +1,8 @@
+title:     Vulnerability to bypass two-factor authentication with unverified JWT trusted device token
+link:      https://github.com/scheb/two-factor-bundle/issues/143
+cve:       ~
+branches:
+    "master":
+        time:     2019-07-08 12:27:02
+        versions: ['<3.7.0']
+reference: composer://scheb/two-factor-bundle

--- a/scheb/two-factor-bundle/2019-12-19.yaml
+++ b/scheb/two-factor-bundle/2019-12-19.yaml
@@ -1,0 +1,14 @@
+title:     Vulnerability to bypass two-factor authentication with remember-me option
+link:      https://github.com/scheb/two-factor-bundle/issues/253
+cve:       ~
+branches:
+    "master":
+        time:     2019-12-19 12:07:42
+        versions: ['>=4.0.0', '<4.11.0']
+    "3.x":
+        time:     2019-12-19 12:04:49
+        versions: ['>=3.0.0', '<3.26.0']
+    "2.x":
+        time:     ~
+        versions: ['>=0.0.0', '<3.0.0']
+reference: composer://scheb/two-factor-bundle


### PR DESCRIPTION
Addding security advisories for `scheb/two-factor-bundle`. One recent one and an older one (but I still see people using that version).