### PR TITLE
Drupal core - Multiple vulnerabilities

### DIFF
--- a/drupal/core/2019-12-18-1.yaml
+++ b/drupal/core/2019-12-18-1.yaml
@@ -1,0 +1,34 @@
+title: Drupal core - Moderately critical - Denial of Service - SA-CORE-2019-009
+link: https://www.drupal.org/sa-core-2019-009
+branches:
+    7.x:
+        time:     ~
+        versions: ['>=7.0.0','<8.0.0']
+    8.0.x:
+        time:     ~
+        versions: ['>=8.0.0','<8.1.0']
+    8.1.x:
+        time:     ~
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     ~
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     ~
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     ~
+        versions: ['>=8.4.0','<8.5.0']
+    8.5.x:
+        time:     ~
+        versions: ['>=8.5.0','<8.6.0']
+    8.6.x:
+        time:     ~
+        versions: ['>=8.6.0','<8.7.0']
+    8.7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.7.0','<8.7.11']
+    8.8.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.8.0','<8.8.1']
+reference: composer://drupal/core

--- a/drupal/core/2019-12-18-2.yaml
+++ b/drupal/core/2019-12-18-2.yaml
@@ -1,0 +1,31 @@
+title: Drupal core - Moderately critical - Multiple vulnerabilities - SA-CORE-2019-010
+link: https://www.drupal.org/sa-core-2019-010
+branches:
+    8.0.x:
+        time:     ~
+        versions: ['>=8.0.0','<8.1.0']
+    8.1.x:
+        time:     ~
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     ~
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     ~
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     ~
+        versions: ['>=8.4.0','<8.5.0']
+    8.5.x:
+        time:     ~
+        versions: ['>=8.5.0','<8.6.0']
+    8.6.x:
+        time:     ~
+        versions: ['>=8.6.0','<8.7.0']
+    8.7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.7.0','<8.7.11']
+    8.8.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.8.0','<8.8.1']
+reference: composer://drupal/core

--- a/drupal/core/2019-12-18-3.yaml
+++ b/drupal/core/2019-12-18-3.yaml
@@ -1,0 +1,31 @@
+title: Drupal core - Moderately critical - Access bypass - SA-CORE-2019-011
+link: https://www.drupal.org/sa-core-2019-011
+branches:
+    8.0.x:
+        time:     ~
+        versions: ['>=8.0.0','<8.1.0']
+    8.1.x:
+        time:     ~
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     ~
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     ~
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     ~
+        versions: ['>=8.4.0','<8.5.0']
+    8.5.x:
+        time:     ~
+        versions: ['>=8.5.0','<8.6.0']
+    8.6.x:
+        time:     ~
+        versions: ['>=8.6.0','<8.7.0']
+    8.7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.7.0','<8.7.11']
+    8.8.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.8.0','<8.8.1']
+reference: composer://drupal/core

--- a/drupal/core/2019-12-18-4.yaml
+++ b/drupal/core/2019-12-18-4.yaml
@@ -1,0 +1,34 @@
+title: Drupal core - Critical - Multiple vulnerabilities - SA-CORE-2019-012
+link: https://www.drupal.org/sa-core-2019-012
+branches:
+    7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=7.0.0','<7.69']
+    8.0.x:
+        time:     ~
+        versions: ['>=8.0.0','<8.1.0']
+    8.1.x:
+        time:     ~
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     ~
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     ~
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     ~
+        versions: ['>=8.4.0','<8.5.0']
+    8.5.x:
+        time:     ~
+        versions: ['>=8.5.0','<8.6.0']
+    8.6.x:
+        time:     ~
+        versions: ['>=8.6.0','<8.7.0']
+    8.7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.7.0','<8.7.11']
+    8.8.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.8.0','<8.8.1']
+reference: composer://drupal/core

--- a/drupal/drupal/2019-12-18-1.yaml
+++ b/drupal/drupal/2019-12-18-1.yaml
@@ -1,0 +1,34 @@
+title: Drupal core - Moderately critical - Denial of Service - SA-CORE-2019-009
+link: https://www.drupal.org/sa-core-2019-009
+branches:
+    7.x:
+        time:     ~
+        versions: ['>=7.0.0','<8.0.0']
+    8.0.x:
+        time:     ~
+        versions: ['>=8.0.0','<8.1.0']
+    8.1.x:
+        time:     ~
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     ~
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     ~
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     ~
+        versions: ['>=8.4.0','<8.5.0']
+    8.5.x:
+        time:     ~
+        versions: ['>=8.5.0','<8.6.0']
+    8.6.x:
+        time:     ~
+        versions: ['>=8.6.0','<8.7.0']
+    8.7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.7.0','<8.7.11']
+    8.8.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.8.0','<8.8.1']
+reference: composer://drupal/drupal

--- a/drupal/drupal/2019-12-18-2.yaml
+++ b/drupal/drupal/2019-12-18-2.yaml
@@ -1,0 +1,31 @@
+title: Drupal core - Moderately critical - Multiple vulnerabilities - SA-CORE-2019-010
+link: https://www.drupal.org/sa-core-2019-010
+branches:
+    8.0.x:
+        time:     ~
+        versions: ['>=8.0.0','<8.1.0']
+    8.1.x:
+        time:     ~
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     ~
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     ~
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     ~
+        versions: ['>=8.4.0','<8.5.0']
+    8.5.x:
+        time:     ~
+        versions: ['>=8.5.0','<8.6.0']
+    8.6.x:
+        time:     ~
+        versions: ['>=8.6.0','<8.7.0']
+    8.7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.7.0','<8.7.11']
+    8.8.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.8.0','<8.8.1']
+reference: composer://drupal/drupal

--- a/drupal/drupal/2019-12-18-3.yaml
+++ b/drupal/drupal/2019-12-18-3.yaml
@@ -1,0 +1,31 @@
+title: Drupal core - Moderately critical - Access bypass - SA-CORE-2019-011
+link: https://www.drupal.org/sa-core-2019-011
+branches:
+    8.0.x:
+        time:     ~
+        versions: ['>=8.0.0','<8.1.0']
+    8.1.x:
+        time:     ~
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     ~
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     ~
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     ~
+        versions: ['>=8.4.0','<8.5.0']
+    8.5.x:
+        time:     ~
+        versions: ['>=8.5.0','<8.6.0']
+    8.6.x:
+        time:     ~
+        versions: ['>=8.6.0','<8.7.0']
+    8.7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.7.0','<8.7.11']
+    8.8.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.8.0','<8.8.1']
+reference: composer://drupal/drupal

--- a/drupal/drupal/2019-12-18-4.yaml
+++ b/drupal/drupal/2019-12-18-4.yaml
@@ -1,0 +1,34 @@
+title: Drupal core - Critical - Multiple vulnerabilities - SA-CORE-2019-012
+link: https://www.drupal.org/sa-core-2019-012
+branches:
+    7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=7.0.0','<7.69']
+    8.0.x:
+        time:     ~
+        versions: ['>=8.0.0','<8.1.0']
+    8.1.x:
+        time:     ~
+        versions: ['>=8.1.0','<8.2.0']
+    8.2.x:
+        time:     ~
+        versions: ['>=8.2.0','<8.3.0']
+    8.3.x:
+        time:     ~
+        versions: ['>=8.3.0','<8.4.0']
+    8.4.x:
+        time:     ~
+        versions: ['>=8.4.0','<8.5.0']
+    8.5.x:
+        time:     ~
+        versions: ['>=8.5.0','<8.6.0']
+    8.6.x:
+        time:     ~
+        versions: ['>=8.6.0','<8.7.0']
+    8.7.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.7.0','<8.7.11']
+    8.8.x:
+        time:     2019-12-18 08:55:00
+        versions: ['>=8.8.0','<8.8.1']
+reference: composer://drupal/drupal


### PR DESCRIPTION
I am not rreally sure about what to do about these descriptions:

> Versions of Drupal 8 prior to 8.7.x are end-of-life and do not receive security coverage.

Should we mark the 7.x and the <8.7.0 as effected or not? Even if we don't know if there is vulnerable code?