### PR TITLE
Add lower version constraint

### DIFF
--- a/scheb/two-factor-bundle/2018-07-08.yaml
+++ b/scheb/two-factor-bundle/2018-07-08.yaml
@@ -4,5 +4,5 @@ cve:       ~
 branches:
     "master":
         time:     2019-07-08 12:27:02
-        versions: ['<3.7.0']
+        versions: ['>=3.0.0', '<3.7.0']
 reference: composer://scheb/two-factor-bundle


### PR DESCRIPTION
Adding the missing lower version constraint for the one issue of `scheb/two-factor-bundle`.