### PR TITLE
Sylius/ResourceBundle, CVE-2020-5220: Ability to define unintended serialisation groups via HTTP header which might lead to data exposure

### DIFF
--- a/sylius/resource-bundle/CVE-2020-5220.yaml
+++ b/sylius/resource-bundle/CVE-2020-5220.yaml
@@ -1,0 +1,26 @@
+title: "CVE-2020-5220: Ability to define unintended serialisation groups via HTTP header which might lead to data exposure"
+link: https://github.com/Sylius/SyliusResourceBundle/security/advisories/GHSA-8vp7-j5cj-vvm2
+cve: CVE-2020-5220
+branches:
+    1.0.x:
+        time: ~
+        versions: ['>=1.0.0', '<1.1.0']
+    1.1.x:
+        time: ~
+        versions: ['>=1.1.0', '<1.2.0']
+    1.2.x:
+        time: ~
+        versions: ['>=1.2.0', '<1.3.0']
+    1.3.x:
+        time: 2020-01-27 13:54:00
+        versions: ['>=1.3.0', '<1.3.13']
+    1.4.x:
+        time: 2020-01-27 13:54:00
+        versions: ['>=1.4.0', '<1.4.6']
+    1.5.x:
+        time: 2020-01-27 13:54:00
+        versions: ['>=1.5.0', '<1.5.0']
+    1.6.x:
+        time: 2020-01-27 13:54:00
+        versions: ['>=1.6.0', '<1.6.3']
+reference: composer://sylius/resource-bundle

--- a/sylius/sylius/CVE-2020-5220.yaml
+++ b/sylius/sylius/CVE-2020-5220.yaml
@@ -1,0 +1,20 @@
+title: "CVE-2020-5220: Ability to define unintended serialisation groups via HTTP header which might lead to data exposure"
+link: https://github.com/Sylius/SyliusResourceBundle/security/advisories/GHSA-8vp7-j5cj-vvm2
+cve: CVE-2020-5220
+branches:
+    1.0.x:
+        time: ~
+        versions: ['>=1.0.0', '<1.1.0']
+    1.1.x:
+        time: ~
+        versions: ['>=1.1.0', '<1.2.0']
+    1.2.x:
+        time: ~
+        versions: ['>=1.2.0', '<1.3.0']
+    1.3.x:
+        time: 2020-01-27 13:54:00
+        versions: ['>=1.3.0', '<1.3.12']
+    1.4.x:
+        time: 2020-01-27 13:54:00
+        versions: ['>=1.4.0', '<1.4.4']
+reference: composer://sylius/sylius


### PR DESCRIPTION
Added entries for `sylius/sylius` (as it used to replace `sylius/resource-bundle`) and also for `sylius/resource-bundle`.

