### PR TITLE
Add CVE-2020-5237: Relative Path Traversal (CWE-23) in chunked uploads

### DIFF
--- a/oneup/uploader-bundle/CVE-2020-5237.yaml
+++ b/oneup/uploader-bundle/CVE-2020-5237.yaml
@@ -3,9 +3,9 @@ link:      https://github.com/1up-lab/OneupUploaderBundle/security/advisories/GH
 cve:       CVE-2020-5237
 branches:
     1.x:
-        time:     2020-01-31 17:03:00
+        time:     2020-02-04 11:41:00
         versions: ['>=1.0.0', '<1.9.3']
     2.x:
-        time:     2020-01-31 17:03:00
+        time:     2020-02-04 11:40:00
         versions: ['>2.0.0', '<2.1.5']
 reference: composer://oneup/uploader-bundle

--- a/oneup/uploader-bundle/CVE-2020-5237.yaml
+++ b/oneup/uploader-bundle/CVE-2020-5237.yaml
@@ -1,0 +1,11 @@
+title:     Relative Path Traversal (CWE-23) in chunked uploads
+link:      https://github.com/1up-lab/OneupUploaderBundle/security/advisories/GHSA-x8wj-6m73-gfqp
+cve:       CVE-2020-5237
+branches:
+    1.x:
+        time:     2020-01-31 17:03:00
+        versions: ['>=1.0.0', '<1.9.3']
+    2.x:
+        time:     2020-01-31 17:03:00
+        versions: ['>2.0.0', '<2.1.5']
+reference: composer://oneup/uploader-bundle


### PR DESCRIPTION
For more information see https://github.com/1up-lab/OneupUploaderBundle/security/advisories/GHSA-x8wj-6m73-gfqp.