### PR TITLE
Fix version constraint

### DIFF
--- a/oneup/uploader-bundle/CVE-2020-5237.yaml
+++ b/oneup/uploader-bundle/CVE-2020-5237.yaml
@@ -7,5 +7,5 @@ branches:
         versions: ['>=1.0.0', '<1.9.3']
     2.x:
         time:     2020-02-04 11:40:00
-        versions: ['>2.0.0', '<2.1.5']
+        versions: ['>=2.0.0', '<2.1.5']
 reference: composer://oneup/uploader-bundle


### PR DESCRIPTION
Sorry to bother you again - I've noticed a little typo as version `2.0.0` is also vulnerable. 