### PR TITLE
Fix mismatched vulnerable version for CVE-2019-12245

### DIFF
--- a/silverstripe/assets/CVE-2019-12245.yaml
+++ b/silverstripe/assets/CVE-2019-12245.yaml
@@ -5,4 +5,7 @@ branches:
     1.0.x:
         time:     2019-09-24 13:49:59
         versions: ['>=1.0.0', '<1.3.5']
+    1.4.x:
+        time:     2019-09-24 13:49:59
+        versions: ['>=1.4.0', '<1.4.4']
 reference: composer://silverstripe/assets


### PR DESCRIPTION
We just noticed we made a mistake when defining which versions are vulnerable.

The vulnerability got fixed in 1.3.5, but version 1.4.0, 1.4.1, 1.4.2 and 1.4.3 are also vulnerable. This PR update the branch list to reflect that.

I also double checked that 1.5.0 isn't vulnerable.

The [public disclosure](https://www.silverstripe.org/download/security-releases/cve-2019-12245) has also been updated to say that you need to upgrade to 1.4.4. 