### PR TITLE
Replaced broken link

### DIFF
--- a/phpunit/phpunit/CVE-2017-9841.yaml
+++ b/phpunit/phpunit/CVE-2017-9841.yaml
@@ -1,5 +1,5 @@
 title: RCE vulnerability in phpunit
-link: http://phpunit.vulnbusters.com/
+link: https://nvd.nist.gov/vuln/detail/CVE-2017-9841
 cve: CVE-2017-9841
 branches:
     5.x:


### PR DESCRIPTION
The previous link to vulnbusters.com no longer functions and may be attempting to trick user into downloading malicious software. I replaced it with a link to nvd.nist.gov. This seemed like a good alternative link.