### PR TITLE
Add entries for issues fixed by Silverstripe CMS 4.6.0 release

### DIFF
--- a/silverstripe/framework/CVE-2019-19326.yaml
+++ b/silverstripe/framework/CVE-2019-19326.yaml
@@ -1,0 +1,14 @@
+title:     'CVE-2019-19326: Web Cache Poisoning through HTTPRequestBuilder'
+link:      https://www.silverstripe.org/download/security-releases/cve-2019-19326/
+cve:       CVE-2019-19326
+branches:
+    4.0.x:
+        time:     2020-07-10 14:57:00
+        versions: ['>=4.0.0', '<4.4.7']
+    4.5.x:
+        time:     2020-07-10 14:57:00
+        versions: ['>=4.5.0', '<4.5.4']
+    3.0.x:
+        time:     2020-07-14 13:25:00
+        versions: ['>=3.0.0', '<3.7.5']
+reference: composer://silverstripe/framework

--- a/silverstripe/framework/CVE-2020-6164.yaml
+++ b/silverstripe/framework/CVE-2020-6164.yaml
@@ -1,0 +1,11 @@
+title:     'CVE-2020-6164: Information disclosure on /interactive URL path'
+link:      https://www.silverstripe.org/download/security-releases/cve-2020-6164/
+cve:       CVE-2020-6164
+branches:
+    4.0.x:
+        time:     2020-07-10 15:03:00
+        versions: ['>=4.0.0', '<4.4.7']
+    4.5.x:
+        time:     2020-07-10 15:03:00
+        versions: ['>=4.5.0', '<4.5.4']
+reference: composer://silverstripe/framework

--- a/silverstripe/framework/CVE-2020-9311.yaml
+++ b/silverstripe/framework/CVE-2020-9311.yaml
@@ -1,0 +1,9 @@
+title:     'CVE-2020-9311: Malicious user profile information can cause login form XSS'
+link:      https://www.silverstripe.org/download/security-releases/cve-2020-9311/
+cve:       CVE-2020-9311
+branches:
+    3.0.x:
+        time:     2020-07-14 13:26:40
+        versions: ['>=3.0.0', '<3.7.5']
+
+reference: composer://silverstripe/framework

--- a/silverstripe/graphql/CVE-2020-6165.yaml
+++ b/silverstripe/graphql/CVE-2020-6165.yaml
@@ -1,0 +1,8 @@
+title:     'CVE-2020-6165: Limited queries break CanViewPermissionChecker'
+link:      https://www.silverstripe.org/download/security-releases/cve-2020-6165
+cve:       CVE-2020-6165
+branches:
+    3.2.x:
+        time:     2020-07-10 17:54:00
+        versions: ['>=3.2.0', '<3.2.4']
+reference: composer://silverstripe/graphql


### PR DESCRIPTION
We released Silverstripe CMS 4.6.0 and related patch releases this week. We disclosed a few security issues with those releases.

