### PR TITLE
Add Laravel vuln in cookie session driver

### DIFF
--- a/illuminate/cookie/2020-07-27-1.yaml
+++ b/illuminate/cookie/2020-07-27-1.yaml
@@ -1,0 +1,14 @@
+title:     RCE vulnerability in "cookie" session driver
+link:      https://blog.laravel.com/laravel-cookie-security-releases
+cve:       ~
+branches:
+    "5.5":
+        time:     ~
+        versions: ['>=5.5.0', '<=5.5.44']
+    "6.x":
+        time:     2020-07-28 18:34:00
+        versions: ['>=6.0.0', '<6.18.31']
+    "7.x":
+        time:     2020-07-28 18:31:00
+        versions: ['>=7.0.0', '<7.22.4']
+reference: composer://illuminate/cookie

--- a/laravel/framework/2020-07-27-1.yaml
+++ b/laravel/framework/2020-07-27-1.yaml
@@ -1,0 +1,14 @@
+title:     RCE vulnerability in "cookie" session driver
+link:      https://blog.laravel.com/laravel-cookie-security-releases
+cve:       ~
+branches:
+    "5.5":
+        time:     ~
+        versions: ['>=5.5.0', '<=5.5.49']
+    "6.x":
+        time:     2020-07-28 18:34:00
+        versions: ['>=6.0.0', '<6.18.31']
+    "7.x":
+        time:     2020-07-28 18:31:00
+        versions: ['>=7.0.0', '<7.22.4']
+reference: composer://laravel/framework


### PR DESCRIPTION
See https://blog.laravel.com/laravel-cookie-security-releases.

I'm not sure if the 5.x branch should be marked as unfixed... :thinking: 

Also: should there be an additional entry for the `illuminate/cookie` package?