### PR TITLE
Add Laravel vuln in eloquent models

### DIFF
--- a/illuminate/database/2020-08-06.yaml
+++ b/illuminate/database/2020-08-06.yaml
@@ -1,0 +1,14 @@
+title:     Guard bypass in Eloquent models
+link:      https://blog.laravel.com/security-release-laravel-61834-7232
+cve:       ~
+branches:
+    "5.5":
+        time:     ~
+        versions: ['>=5.5.0', '<=5.5.44']
+    "6.x":
+        time:     2020-08-06 14:55:00
+        versions: ['>=6.0.0', '<6.18.34']
+    "7.x":
+        time:     2020-08-06 14:56:00
+        versions: ['>=7.0.0', '<7.23.2']
+reference: composer://illuminate/database

--- a/laravel/framework/2020-08-06-1.yaml
+++ b/laravel/framework/2020-08-06-1.yaml
@@ -1,0 +1,14 @@
+title:     Guard bypass in Eloquent models
+link:      https://blog.laravel.com/security-release-laravel-61834-7232
+cve:       ~
+branches:
+    "5.5":
+        time:     ~
+        versions: ['>=5.5.0', '<=5.5.49']
+    "6.x":
+        time:     2020-08-06 14:55:00
+        versions: ['>=6.0.0', '<6.18.34']
+    "7.x":
+        time:     2020-08-06 14:56:00
+        versions: ['>=7.0.0', '<7.23.2']
+reference: composer://laravel/framework


### PR DESCRIPTION
See https://blog.laravel.com/security-release-laravel-61834-7232.

I'm not sure if the 5.x branch should be marked as unfixed... :thinking: 

Also: should there be an additional entry for the `illuminate/database` package?