### PR TITLE
Add Livewire 2.2.5 validation advisory

### DIFF
--- a/livewire/livewire/2020-09-22-1.yaml
+++ b/livewire/livewire/2020-09-22-1.yaml
@@ -4,5 +4,5 @@ cve:       ~
 branches:
     2.x:
         time:     2020-09-22 19:30:08
-        versions: ['2.2.5']
+        versions: ['>2.2.4', '<2.2.6']
 reference: composer://livewire/livewire

--- a/livewire/livewire/2020-09-22-1.yaml
+++ b/livewire/livewire/2020-09-22-1.yaml
@@ -1,0 +1,8 @@
+title:     $this->validate() returns all properties, not just validated ones
+link:      https://github.com/livewire/livewire/releases/tag/v2.2.6
+cve:       ~
+branches:
+    2.x:
+        time:     2020-09-22 19:30:08
+        versions: ['2.2.5']
+reference: composer://livewire/livewire


### PR DESCRIPTION
Notes a validation issue introduced in Livewire 2.2.5 (and then fixed in 2.2.6) whereby the `Component::validate()` method returns all property data instead of just the validated properties as it previously had. This regression could potentially cause security issues if the return value was used with unguarded models or other scenarios, if the other property names lined up.

https://github.com/livewire/livewire/releases/tag/v2.2.6