### PR TITLE
Add 2020 CVEs for MediaWiki

### DIFF
--- a/mediawiki/core/CVE-2020-10959.yaml
+++ b/mediawiki/core/CVE-2020-10959.yaml
@@ -1,0 +1,8 @@
+title:     User content can redirect the logout button to different URL
+link:      https://phabricator.wikimedia.org/T232932
+reference: composer://mediawiki/core
+cve:       CVE-2020-10959
+branches:
+    1.34.x:
+        time: 2020-03-26 14:02:20
+        versions: ['>=1.34.0', '<1.34.1']

--- a/mediawiki/core/CVE-2020-10960.yaml
+++ b/mediawiki/core/CVE-2020-10960.yaml
@@ -1,0 +1,14 @@
+title:     makeCollapsible allows applying event handler to any CSS selector
+link:      https://phabricator.wikimedia.org/T246602
+reference: composer://mediawiki/core
+cve:       CVE-2020-10960
+branches:
+    1.31.x:
+        time: 2020-03-26 14:05:20
+        versions: ['>=1.31.0', '<1.31.7']
+    1.33.x:
+        time: 2020-03-26 14:04:28
+        versions: ['>=1.33.0', '<1.33.3']
+    1.34.x:
+        time: 2020-03-26 14:02:20
+        versions: ['>=1.34.0', '<1.34.1']

--- a/mediawiki/core/CVE-2020-25812.yaml
+++ b/mediawiki/core/CVE-2020-25812.yaml
@@ -1,0 +1,11 @@
+title:     Unescaped message used in HTML on Special:Contributions
+link:      https://phabricator.wikimedia.org/T255918
+reference: composer://mediawiki/core
+cve:       CVE-2020-25812
+branches:
+    1.34.x:
+        time: 2020-09-24 01:38:27
+        versions: ['>=1.34.0', '<1.34.3']
+    1.35.x:
+        time: 2020-09-24 17:14:47
+        versions: ['>=1.34.99', '<1.35.0']

--- a/mediawiki/core/CVE-2020-25813.yaml
+++ b/mediawiki/core/CVE-2020-25813.yaml
@@ -1,0 +1,11 @@
+title:     Special:UserRights exposes the existence of hidden users
+link:      https://phabricator.wikimedia.org/T232568
+reference: composer://mediawiki/core
+cve:       CVE-2020-25813
+branches:
+    1.31.x:
+        time: 2020-09-21 18:17:37
+        versions: ['>=1.31.0', '<1.31.9']
+    1.34.x:
+        time: 2020-09-21 16:46:08
+        versions: ['>=1.34.0', '<1.34.3']

--- a/mediawiki/core/CVE-2020-25814.yaml
+++ b/mediawiki/core/CVE-2020-25814.yaml
@@ -1,0 +1,14 @@
+title:     'mw.message.parse() accepts javascript: protocol in wikilinks'
+link:      https://phabricator.wikimedia.org/T86738
+reference: composer://mediawiki/core
+cve:       CVE-2020-25814
+branches:
+    1.31.x:
+        time: 2020-09-24 01:25:00
+        versions: ['>=1.31.0', '<1.31.9']
+    1.34.x:
+        time: 2020-09-24 01:38:27
+        versions: ['>=1.34.0', '<1.34.3']
+    1.35.x:
+        time: 2020-09-24 17:14:47
+        versions: ['>=1.34.99', '<1.35.0']

--- a/mediawiki/core/CVE-2020-25815.yaml
+++ b/mediawiki/core/CVE-2020-25815.yaml
@@ -1,0 +1,11 @@
+title:     Unescaped message used in HTML within LogEventsList
+link:      https://phabricator.wikimedia.org/T256171
+reference: composer://mediawiki/core
+cve:       CVE-2020-25815
+branches:
+    1.34.x:
+        time: 2020-09-24 01:38:27
+        versions: ['>=1.34.0', '<1.34.3']
+    1.35.x:
+        time: 2020-09-24 17:14:47
+        versions: ['>=1.34.99', '<1.35.0']

--- a/mediawiki/core/CVE-2020-25827.yaml
+++ b/mediawiki/core/CVE-2020-25827.yaml
@@ -1,0 +1,11 @@
+title:     TOTP throttle not enforced cross-wiki
+link:      https://phabricator.wikimedia.org/T251661
+reference: composer://mediawiki/core
+cve:       CVE-2020-25827
+branches:
+    1.31.x:
+        time: ~
+        versions: ['>=1.31.0', '<1.31.9']
+    1.34.x:
+        time: ~
+        versions: ['>=1.34.0', '<1.34.3']

--- a/mediawiki/core/CVE-2020-25828.yaml
+++ b/mediawiki/core/CVE-2020-25828.yaml
@@ -1,0 +1,14 @@
+title:     Non-jqueryMsg version of mw.message(…).parse() doesn't escape HTML
+link:      https://phabricator.wikimedia.org/T115888
+reference: composer://mediawiki/core
+cve:       CVE-2020-25828
+branches:
+    1.31.x:
+        time: 2020-09-24 01:26:41
+        versions: ['>=1.31.0', '<1.31.9']
+    1.34.x:
+        time: 2020-09-24 01:38:27
+        versions: ['>=1.34.0', '<1.34.3']
+    1.35.x:
+        time: 2020-09-24 17:14:47
+        versions: ['>=1.34.99', '<1.35.0']


### PR DESCRIPTION
I am not entirely sure about the constraint for vulnerabilities that only affect the RC versions of 1.35 :slightly_frowning_face: 