### PR TITLE
Add 2020 CVEs for phpmyadmin

### DIFF
--- a/phpmyadmin/phpmyadmin/CVE-2020-10802.yaml
+++ b/phpmyadmin/phpmyadmin/CVE-2020-10802.yaml
@@ -1,0 +1,11 @@
+title:     SQL injection relating to searching
+link:      https://www.phpmyadmin.net/security/PMASA-2020-3/
+reference: composer://phpmyadmin/phpmyadmin
+cve:       CVE-2020-10802
+branches:
+    4.9.x:
+        time: 2020-01-18 22:13:03
+        versions: ['>=4.9.0', '<4.9.5']
+    5.0.x:
+        time: 2020-01-18 22:13:03
+        versions: ['>=5.0.0', '<5.0.2']

--- a/phpmyadmin/phpmyadmin/CVE-2020-10803.yaml
+++ b/phpmyadmin/phpmyadmin/CVE-2020-10803.yaml
@@ -1,0 +1,11 @@
+title:     SQL injection relating to data display
+link:      https://www.phpmyadmin.net/security/PMASA-2020-4/
+reference: composer://phpmyadmin/phpmyadmin
+cve:       CVE-2020-10803
+branches:
+    4.9.x:
+        time: 2020-03-05 17:34:49
+        versions: ['>=3.4', '<4.9.5']
+    5.0.x:
+        time: 2020-03-05 17:34:49
+        versions: ['>=5.0.0', '<5.0.2']

--- a/phpmyadmin/phpmyadmin/CVE-2020-10804.yaml
+++ b/phpmyadmin/phpmyadmin/CVE-2020-10804.yaml
@@ -1,0 +1,11 @@
+title:     SQL injection with processing username
+link:      https://www.phpmyadmin.net/security/PMASA-2020-2/
+reference: composer://phpmyadmin/phpmyadmin
+cve:       CVE-2020-10804
+branches:
+    4.9.x:
+        time: 2020-03-18 22:16:53
+        versions: ['>=4.9.0', '<4.9.5']
+    5.0.x:
+        time: 2020-03-18 22:16:53
+        versions: ['>=5.0.0', '<5.0.2']

--- a/phpmyadmin/phpmyadmin/CVE-2020-26934.yaml
+++ b/phpmyadmin/phpmyadmin/CVE-2020-26934.yaml
@@ -1,0 +1,11 @@
+title:     XSS relating to the transformation feature
+link:      https://www.phpmyadmin.net/security/PMASA-2020-5/
+reference: composer://phpmyadmin/phpmyadmin
+cve:       CVE-2020-26934
+branches:
+    4.9.x:
+        time: 2020-05-17 12:26:47
+        versions: ['>=4.9.0', '<4.9.6']
+    5.0.x:
+        time: 2020-05-17 12:26:47
+        versions: ['>=5.0.0', '<5.0.3']

--- a/phpmyadmin/phpmyadmin/CVE-2020-26935.yaml
+++ b/phpmyadmin/phpmyadmin/CVE-2020-26935.yaml
@@ -1,0 +1,11 @@
+title:     SQL injection vulnerability in SearchController
+link:      https://www.phpmyadmin.net/security/PMASA-2020-6/
+reference: composer://phpmyadmin/phpmyadmin
+cve:       CVE-2020-26935
+branches:
+    4.9.x:
+        time: 2020-07-03 17:45:58
+        versions: ['>=4.9.0', '<4.9.6']
+    5.0.x:
+        time: 2020-07-03 17:45:58
+        versions: ['>=5.0.0', '<5.0.3']

--- a/phpmyadmin/phpmyadmin/CVE-2020-5504.yaml
+++ b/phpmyadmin/phpmyadmin/CVE-2020-5504.yaml
@@ -1,0 +1,11 @@
+title:     SQL injection in user accounts page
+link:      https://www.phpmyadmin.net/security/PMASA-2020-1/
+reference: composer://phpmyadmin/phpmyadmin
+cve:       CVE-2020-5504
+branches:
+    4.x:
+        time: 2020-01-01 13:54:59
+        versions: ['>=4.0.0', '<4.9.4']
+    5.0.x:
+        time: 2020-01-01 13:54:59
+        versions: ['>=5.0.0', '<5.0.1']


### PR DESCRIPTION
Similar to https://github.com/FriendsOfPHP/security-advisories/pull/502#discussion_r527120521, I could not always find the first vulnerable version.