### PR TITLE
Add assigned CVEs to Drupal advisories

### DIFF
--- a/drupal/core/CVE-2018-9861.yaml
+++ b/drupal/core/CVE-2018-9861.yaml
@@ -1,5 +1,6 @@
 title: Moderately critical - Cross Site Scripting
 link: https://www.drupal.org/sa-core-2018-003
+cve: CVE-2018-9861
 branches:
     8.0.x:
         time:     ~

--- a/drupal/core/CVE-2019-10909.yaml
+++ b/drupal/core/CVE-2019-10909.yaml
@@ -1,5 +1,6 @@
 title: Drupal core - Moderately critical - Multiple Vulnerabilities - SA-CORE-2019-005
 link: https://www.drupal.org/sa-core-2019-005
+cve: CVE-2019-10909
 branches:
   7.x:
     time:    2019-04-17 22:31:00
@@ -25,4 +26,4 @@ branches:
   8.6.x:
     time:     2019-04-17 22:31:00
     versions: ['>=8.6.0','<8.6.14']
-reference: composer://drupal/drupal
+reference: composer://drupal/core

--- a/drupal/drupal/CVE-2018-9861.yaml
+++ b/drupal/drupal/CVE-2018-9861.yaml
@@ -1,5 +1,6 @@
 title: Moderately critical - Cross Site Scripting
 link: https://www.drupal.org/sa-core-2018-003
+cve: CVE-2018-9861
 branches:
     8.0.x:
         time:     ~

--- a/drupal/drupal/CVE-2019-10909.yaml
+++ b/drupal/drupal/CVE-2019-10909.yaml
@@ -1,5 +1,6 @@
 title: Drupal core - Moderately critical - Multiple Vulnerabilities - SA-CORE-2019-005
 link: https://www.drupal.org/sa-core-2019-005
+cve: CVE-2019-10909
 branches:
   7.x:
     time:    2019-04-17 22:31:00
@@ -25,4 +26,4 @@ branches:
   8.6.x:
     time:     2019-04-17 22:31:00
     versions: ['>=8.6.0','<8.6.14']
-reference: composer://drupal/core
+reference: composer://drupal/drupal


### PR DESCRIPTION
Quick note, the 2019 Drupal advisory lists three separate CVEs. Both the 2018 and 2019 advisories are caused by underlying libraries used by Drupal: for 2018, CKEditor, for 2019, Symfony. If you look at the CVE data, Drupal is listed as a vulnerable configuration, but only for one of the 2019 CVEs:

* https://nvd.nist.gov/vuln/detail/CVE-2018-9861
* https://nvd.nist.gov/vuln/detail/CVE-2019-10909
* https://nvd.nist.gov/vuln/detail/CVE-2019-10910
* https://nvd.nist.gov/vuln/detail/CVE-2019-10911

It might be worth reaching out to the maintainers of the NIST NVD to add Drupal as a vulnerable configuration on the last two CVEs listed above.