### PR TITLE
Create CVE-2020-36193.yaml (#1)

### DIFF
--- a/pear/archive_tar/CVE-2020-36193.yaml
+++ b/pear/archive_tar/CVE-2020-36193.yaml
@@ -1,0 +1,8 @@
+title: Allows write operations with Directory Traversal due to inadequate checking of symbolic links
+link: https://github.com/pear/Archive_Tar/commit/cde460582ff389404b5b3ccb59374e9b389de916
+cve: CVE-2020-36193
+branches:
+    1.x:
+        time: 2021-01-18 00:00:00
+        versions: ['<1.4.12']
+reference: composer://pear/archive_tar


### PR DESCRIPTION
CVE-2020-36193 

Archive_Tar through 1.4.11 allows write operations with Directory Traversal due to inadequate checking of symbolic links (a related issue to CVE-2020-28948)