### PR TITLE
Update Laravel database advisory

### DIFF
--- a/illuminate/database/CVE-2021-21263.yaml
+++ b/illuminate/database/CVE-2021-21263.yaml
@@ -1,14 +1,14 @@
 title:     Unexpected bindings in QueryBuilder
 link:      https://blog.laravel.com/security-laravel-62011-7302-8221-released
-cve:       ~
+cve:       CVE-2021-21263
 branches:
     "6.x":
         time:     2020-01-13 14:35:00
-        versions: ['>=6.0.0', '<6.20.11']
+        versions: ['>=6.0.0', '<6.20.14']
     "7.x":
         time:     2020-01-13 14:37:00
-        versions: ['>=7.0.0', '<7.30.2']
+        versions: ['>=7.0.0', '<7.30.4']
     "8.x":
         time:     2020-01-13 14:37:00
-        versions: ['>=8.0.0', '<8.22.1']
-reference: composer://laravel/framework
+        versions: ['>=8.0.0', '<8.24.0']
+reference: composer://illuminate/database

--- a/laravel/framework/CVE-2021-21263.yaml
+++ b/laravel/framework/CVE-2021-21263.yaml
@@ -1,14 +1,14 @@
 title:     Unexpected bindings in QueryBuilder
 link:      https://blog.laravel.com/security-laravel-62011-7302-8221-released
-cve:       ~
+cve:       CVE-2021-21263
 branches:
     "6.x":
         time:     2020-01-13 14:35:00
-        versions: ['>=6.0.0', '<6.20.11']
+        versions: ['>=6.0.0', '<6.20.14']
     "7.x":
         time:     2020-01-13 14:37:00
-        versions: ['>=7.0.0', '<7.30.2']
+        versions: ['>=7.0.0', '<7.30.4']
     "8.x":
         time:     2020-01-13 14:37:00
-        versions: ['>=8.0.0', '<8.22.1']
-reference: composer://illuminate/database
+        versions: ['>=8.0.0', '<8.24.0']
+reference: composer://laravel/framework


### PR DESCRIPTION
The previous fix could be bypassed, so new versions were released.

Source:
* https://github.com/laravel/framework/pull/35865#discussion_r561578503
* https://github.com/laravel/framework/pull/35972