### PR TITLE
Simplify regexp

### DIFF
--- a/validator.php
+++ b/validator.php
@@ -63,7 +63,12 @@ final class Validate extends Command
         };
 
         $isAcceptableVersionConstraint = function ($versionString) {
-            return (bool) preg_match('/^[<>]=?(([1-9]\d*)|0)(\.(([1-9]\d*)|0))*(-(alpha|beta|rc|p(atch)?)[1-9]\d*)?$/', $versionString);
+            return (bool) preg_match('/^
+                [<>]=?
+                (([1-9]\d*)|0)
+                (\.(([1-9]\d*)|0))*
+                (-(alpha|beta|rc|p(atch)?)[1-9]\d*)?
+            $/x', $versionString);
         };
 
         $messages = array();

--- a/validator.php
+++ b/validator.php
@@ -63,7 +63,7 @@ final class Validate extends Command
         };
 
         $isAcceptableVersionConstraint = function ($versionString) {
-            return (bool) preg_match('/^(\\<|\\>)(=){0,1}(([1-9]\d*)|0)(\.(([1-9]\d*)|0))*(-(alpha|beta|rc|p(atch)?)[1-9]\d*){0,1}$/', $versionString);
+            return (bool) preg_match('/^([<>])(=)?(([1-9]\d*)|0)(\.(([1-9]\d*)|0))*(-(alpha|beta|rc|p(atch)?)[1-9]\d*)?$/', $versionString);
         };
 
         $messages = array();
@@ -152,7 +152,7 @@ final class Validate extends Command
                 $upperBoundWithoutLowerBound = null;
 
                 foreach ($data['branches'] as $name => $branch) {
-                    if (!preg_match('/^([\d\.\-]+(\.x)?(\-dev)?|master)$/', $name)) {
+                    if (!preg_match('/^([\d.\-]+(\.x)?(-dev)?|master)$/', $name)) {
                         $messages[$path][] = sprintf('Invalid branch name "%s".', $name);
                     }
 

--- a/validator.php
+++ b/validator.php
@@ -63,7 +63,7 @@ final class Validate extends Command
         };
 
         $isAcceptableVersionConstraint = function ($versionString) {
-            return (bool) preg_match('/^([<>])(=)?(([1-9]\d*)|0)(\.(([1-9]\d*)|0))*(-(alpha|beta|rc|p(atch)?)[1-9]\d*)?$/', $versionString);
+            return (bool) preg_match('/^[<>]=?(([1-9]\d*)|0)(\.(([1-9]\d*)|0))*(-(alpha|beta|rc|p(atch)?)[1-9]\d*)?$/', $versionString);
         };
 
         $messages = array();


### PR DESCRIPTION
This does the same thing but with a slighty easier to read syntax:
* `(\\<|\\>)` can be simplified as `([<>])`.
* `{0,1}` can be simplified as `?`.
* Escaping `.` is not required in `[]`.
* Escaping `-`  is not required outside `[]`.