### PR TITLE
Adds Record For facade/ignition RCE: CVE-2021-3129

### DIFF
--- a/facade/ignition/CVE-2021-3129.yaml
+++ b/facade/ignition/CVE-2021-3129.yaml
@@ -1,0 +1,8 @@
+title:     Remote code execution
+link:      https://github.com/facade/ignition/pull/334
+cve:       CVE-2021-3129
+branches:
+    "master":
+        time:     2020-11-17 09:18:00
+        versions: ['<=2.5.1']
+reference: composer://facade/ignition

--- a/facade/ignition/CVE-2021-3129.yaml
+++ b/facade/ignition/CVE-2021-3129.yaml
@@ -4,5 +4,8 @@ cve:       CVE-2021-3129
 branches:
     "master":
         time:     2020-11-17 09:18:00
-        versions: ['<=2.5.1']
+        versions: ['<=2.5.1', '>=2.0']
+    "1.x":
+        time:     2021-02-13 10:47:03
+        versions: ['<=1.16.13']
 reference: composer://facade/ignition

--- a/facade/ignition/CVE-2021-3129.yaml
+++ b/facade/ignition/CVE-2021-3129.yaml
@@ -5,7 +5,4 @@ branches:
     "master":
         time:     2020-11-17 09:18:00
         versions: ['<=2.5.1']
-    "v1":
-        time:     2021-02-13 10:47:03
-        versions: ['<=1.16.13']
 reference: composer://facade/ignition

--- a/facade/ignition/CVE-2021-3129.yaml
+++ b/facade/ignition/CVE-2021-3129.yaml
@@ -5,4 +5,7 @@ branches:
     "master":
         time:     2020-11-17 09:18:00
         versions: ['<=2.5.1']
+    "v1":
+        time:     2021-02-13 10:47:03
+        versions: ['<=1.16.13']
 reference: composer://facade/ignition


### PR DESCRIPTION
This PR adds a record for the facade/ignition RCE vulnerability.

- https://www.ambionics.io/blog/laravel-debug-rce
- https://github.com/facade/ignition/pull/334
- https://github.com/facade/ignition/pull/353