### PR TITLE
Cleanup facade/ignition entry

### DIFF
--- a/facade/ignition/CVE-2021-3129.yaml
+++ b/facade/ignition/CVE-2021-3129.yaml
@@ -4,11 +4,11 @@ cve:       CVE-2021-3129
 branches:
     "master":
         time:     2020-11-17 09:18:00
-        versions: ['<=2.5.1', '>=2.5.0']
+        versions: ['>=2.5.0', '<2.5.2']
     "2.4.x":
-        time:     2020-11-17 09:18:00
-        versions: ['<=2.4.1', ">=2.0.0"]
+        time:     2021-02-18 12:38:00
+        versions: [">=2.0.0", '<2.4.2']
     "1.x":
         time:     2021-02-13 10:47:03
-        versions: ['<=1.16.13']
+        versions: ['<1.16.14']
 reference: composer://facade/ignition


### PR DESCRIPTION
See:
https://github.com/FriendsOfPHP/security-advisories/pull/545#discussion_r602150214

* constraints reversed, having minimum version first
* Changed max version constraint to `<`
* updated timestamp to match the fix PR time for 2.4.x