### PR TITLE
phpseclib CVE-2021-30130

### DIFF
--- a/phpseclib/phpseclib/CVE-2021-30130.yaml
+++ b/phpseclib/phpseclib/CVE-2021-30130.yaml
@@ -1,0 +1,11 @@
+title:     Improper Certificate Validation in phpseclib
+link:      https://github.com/phpseclib/phpseclib/pull/1635
+cve:       CVE-2021-30130
+branches:
+    "2.0":
+        time:     2021-04-06 13:43:13
+        versions: ['<2.0.31']
+    "3.0":
+        time:     2021-04-06 14:00:11
+        versions: ['>= 3.0.0', '< 3.0.7']
+reference: composer://phpseclib/phpseclib

--- a/phpseclib/phpseclib/CVE-2021-30130.yaml
+++ b/phpseclib/phpseclib/CVE-2021-30130.yaml
@@ -7,5 +7,5 @@ branches:
         versions: ['<2.0.31']
     "3.0":
         time:     2021-04-06 14:00:11
-        versions: ['>= 3.0.0', '< 3.0.7']
+        versions: ['>=3.0.0', '<3.0.7']
 reference: composer://phpseclib/phpseclib


### PR DESCRIPTION
phpseclib before 2.0.31 and 3.x before 3.0.7 mishandles RSA PKCS#1 v1.5 signature verification.

**References**

- https://nvd.nist.gov/vuln/detail/CVE-2021-30130
- phpseclib/phpseclib#1635
- https://github.com/phpseclib/phpseclib/releases/tag/2.0.31
- https://github.com/phpseclib/phpseclib/releases/tag/3.0.7