### PR TITLE
Add neos/* advisories

### DIFF
--- a/neos/flow/2012-03-28.yaml
+++ b/neos/flow/2012-03-28.yaml
@@ -1,0 +1,8 @@
+title:     Insecure Unserialize Vulnerability in FLOW3
+link:      https://www.neos.io/blog/flow-sa-2012-001.html
+cve:       ~
+branches:
+    1.0.x:
+        time:     2012-03-28 09:32:37
+        versions: ['>=1.0.0', '<1.0.4']
+reference: composer://neos/flow

--- a/neos/flow/2015-11-23.yaml
+++ b/neos/flow/2015-11-23.yaml
@@ -1,0 +1,11 @@
+title:     Arbitrary file upload and XML External Entity processing
+link:      https://www.neos.io/blog/flow-sa-2015-001.html
+cve:       ~
+branches:
+    2.3.x:
+        time:     2015-11-23 09:24:00
+        versions: ['>=2.3.0', '<2.3.7']
+    3.0.x:
+        time:     2015-11-23 09:24:00
+        versions: ['>=3.0.0', '<3.0.1']
+reference: composer://neos/flow

--- a/neos/flow/2016-11-01.yaml
+++ b/neos/flow/2016-11-01.yaml
@@ -1,0 +1,21 @@
+title:     Time-Based Information Disclosure Vulnerability in Flow
+link:      https://www.neos.io/blog/flow-sa-2016-001.html
+cve:       ~
+branches:
+    2.3.x:
+        time:     2016-11-01 17:00:00
+        versions: ['>=2.3.0', '<2.3.16']
+    3.0.x:
+        time:     2016-11-01 17:00:00
+        versions: ['>=3.0.0', '<3.0.10']
+    3.1.x:
+        time:     2016-11-01 17:00:00
+        versions: ['>=3.1.0', '<3.1.7']
+    3.2.x:
+        time:     2016-11-01 17:00:00
+        versions: ['>=3.2.0', '<3.2.7']
+    3.3.x:
+        time:     2016-11-01 17:00:00
+        versions: ['>=3.3.0', '<3.3.5']
+
+reference: composer://neos/flow

--- a/neos/flow/2017-04-12.yaml
+++ b/neos/flow/2017-04-12.yaml
@@ -1,0 +1,21 @@
+title:     Flow Bugfix Releases for Entity Security
+link:      https://www.neos.io/blog/flow-bugfix-releases-for-entity-security.html
+cve:       ~
+branches:
+    3.0.x:
+        time:     2017-04-12 17:00:00
+        versions: ['>=3.0.0', '<3.0.12']
+    3.1.x:
+        time:     2017-04-12 17:00:00
+        versions: ['>=3.1.0', '<3.1.10']
+    3.2.x:
+        time:     2017-04-12 17:00:00
+        versions: ['>=3.2.0', '<3.2.13']
+    3.3.x:
+        time:     2017-04-12 17:00:00
+        versions: ['>=3.3.0', '<3.3.13']
+    4.0.x:
+        time:     2017-04-12 17:00:00
+        versions: ['>=4.0.0', '<4.0.6']
+
+reference: composer://neos/flow

--- a/neos/flow/CVE-2013-7082.yaml
+++ b/neos/flow/CVE-2013-7082.yaml
@@ -1,0 +1,11 @@
+title:     Cross-Site Scripting in TYPO3 Flow
+link:      https://www.neos.io/blog/flow-sa-2013-001.html
+cve:       CVE-2013-7082
+branches:
+    1.1.x:
+        time:     2013-12-10 13:44:06
+        versions: ['>=1.1.0', '<1.1.1']
+    2.0.x:
+        time:     2013-12-10 11:47:14
+        versions: ['>=2.0.0', '<2.0.1']
+reference: composer://neos/flow

--- a/neos/neos/2015-03-28.yaml
+++ b/neos/neos/2015-03-28.yaml
@@ -1,0 +1,11 @@
+title:     Privilege Escalation in TYPO3 Neos
+link:      https://www.neos.io/blog/neos-sa-2015-001.html
+cve:       ~
+branches:
+    1.1.x:
+        time:     2015-03-28 18:26:25
+        versions: ['>=1.1.0', '<1.1.3']
+    1.2.x:
+        time:     2015-03-28 18:24:29
+        versions: ['>=1.2.0', '<1.2.3']
+reference: composer://neos/neos

--- a/neos/neos/2015-11-23.yaml
+++ b/neos/neos/2015-11-23.yaml
@@ -1,0 +1,11 @@
+title:     XSS vulnerabilities in Neos
+link:      https://www.neos.io/blog/neos-sa-2015-002.html
+cve:       ~
+branches:
+    1.2.x:
+        time:     2015-11-23 21:03:00
+        versions: ['>=1.2.0', '<1.2.13']
+    2.0.x:
+        time:     2015-11-23 21:03:00
+        versions: ['>=2.0.0', '<2.0.4']
+reference: composer://neos/neos

--- a/neos/neos/2019-06-17.yaml
+++ b/neos/neos/2019-06-17.yaml
@@ -1,0 +1,32 @@
+title:     Information Disclosure Security Note
+link:      https://www.neos.io/blog/neos-workspace-disclosure-security.html
+cve:       ~
+branches:
+    2.3.x:
+        time:     2019-06-17 17:00:00
+        versions: ['>=2.3.0', '<2.9.99']
+    3.0.x:
+        time:     2019-06-17 17:00:00
+        versions: ['>=3.0.0', '<3.0.20']
+    3.1.x:
+        time:     2019-06-17 17:00:00
+        versions: ['>=3.1.0', '<3.1.18']
+    3.2.x:
+        time:     2019-06-17 17:00:00
+        versions: ['>=3.2.0', '<3.2.14']
+    3.3.x:
+        time:     2019-06-17 17:00:00
+        versions: ['>=3.3.0', '<3.3.23']
+    4.0.x:
+        time:     2019-06-17 17:00:00
+        versions: ['>=4.0.0', '<4.0.17']
+    4.1.x:
+        time:     2019-06-17 17:00:00
+        versions: ['>=4.1.0', '<4.1.16']
+    4.2.x:
+        time:     2019-06-17 17:00:00
+        versions: ['>=4.2.0', '<4.2.12']
+    4.3.x:
+        time:     2019-06-17 17:00:00
+        versions: ['>=4.3.0', '<4.3.3']
+reference: composer://neos/neos

--- a/neos/swiftmailer/2017-01-06.yaml
+++ b/neos/swiftmailer/2017-01-06.yaml
@@ -1,0 +1,12 @@
+title:     Security fix for Flow Swift Mailer package
+link:      https://www.neos.io/blog/flow-sa-2017-01.html
+cve:       ~
+branches:
+    4.1.x:
+        time:     2017-01-06 17:00:00
+        versions: ['>=4.1.0', '<4.1.99']
+    5.4.x:
+        time:     2017-01-06 17:00:00
+        versions: ['>=5.4.0', '<5.4.5']
+
+reference: composer://neos/swiftmailer


### PR DESCRIPTION
This adds advisories for neos/* under the neos vendor name, those
packages replace the ones from typo3/*.