### PR TITLE
Add advisory for rmccue/requests 1.6.0 < 1.8.0

### DIFF
--- a/rmccue/requests/CVE-2021-29476.yaml
+++ b/rmccue/requests/CVE-2021-29476.yaml
@@ -1,0 +1,8 @@
+title:     Insecure Deserialization of untrusted data
+link:      https://github.com/WordPress/Requests/security/advisories/GHSA-52qp-jpq7-6c54
+cve:       CVE-2021-29476
+reference: composer://rmccue/requests
+branches:
+    1.x:
+        time:     2020-11-03 08:51:20
+        versions: ['>=1.6.0', '<1.8.0']


### PR DESCRIPTION
See:
* https://github.com/WordPress/Requests/releases/tag/v1.8.0
* https://github.com/WordPress/Requests/security/advisories/GHSA-52qp-jpq7-6c54