### PR TITLE
Fix non-existant version for symfony/security

### DIFF
--- a/symfony/security/CVE-2020-5275.yaml
+++ b/symfony/security/CVE-2020-5275.yaml
@@ -5,7 +5,4 @@ branches:
     4.4.x:
         time:     2020-03-30 14:00:00
         versions: ['>=4.4.0', '<4.4.7']
-    5.0.x:
-        time:     2020-03-30 14:00:00
-        versions: ['>=5.0.0', '<5.0.7']
 reference: composer://symfony/security

--- a/symfony/security/CVE-2021-21424.yaml
+++ b/symfony/security/CVE-2021-21424.yaml
@@ -35,13 +35,4 @@ branches:
     4.4.x:
         time:     2021-05-12 08:00:00
         versions: ['>=4.4.0', '<4.4.23']
-    5.0.x:
-        time:     2021-05-12 08:00:00
-        versions: ['>=5.0.0', '<5.1.0']
-    5.1.x:
-        time:     2021-05-12 08:00:00
-        versions: ['>=5.1.0', '<5.2.0']
-    5.2.x:
-        time:     2021-05-12 08:00:00
-        versions: ['>=5.2.0', '<5.2.8']
 reference: composer://symfony/security


### PR DESCRIPTION
There are no version after 4.x for the symfony/security component