### PR TITLE
Add wp-cli/wp-cli CVE-2021-29504

### DIFF
--- a/wp-cli/wp-cli/CVE-2021-29504.yaml
+++ b/wp-cli/wp-cli/CVE-2021-29504.yaml
@@ -1,0 +1,14 @@
+title:     Insecure Deserialization of untrusted data
+link:      https://github.com/wp-cli/wp-cli/security/advisories/GHSA-rwgm-f83r-v3qj
+cve:       CVE-2021-29504
+reference: composer://wp-cli/wp-cli
+branches:
+    0.x:
+        time:     2021-05-14 14:37:47
+        versions: ['>=0.12.0', '<1.0.0']
+    1.x:
+        time:     2021-05-14 14:37:47
+        versions: ['>=1.0.0', '<2.0.0']
+    2.x:
+        time:     2021-05-14 14:37:47
+        versions: ['>=2.0.0', '<2.5.0']


### PR DESCRIPTION
See:
- [CVE-2021-29504](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-29504)
- [GitHub advisory GHSA-rwgm-f83r-v3qj](https://github.com/wp-cli/wp-cli/security/advisories/GHSA-rwgm-f83r-v3qj)
- [WP-CLI v2.5.0 release notes](https://make.wordpress.org/cli/2021/05/19/wp-cli-v2-5-0-release-notes/)