### PR TITLE
Fix title in wp-cli/wp-cli CVE-2021-29504

### DIFF
--- a/wp-cli/wp-cli/CVE-2021-29504.yaml
+++ b/wp-cli/wp-cli/CVE-2021-29504.yaml
@@ -1,4 +1,4 @@
-title:     Insecure Deserialization of untrusted data
+title:     Improper Certificate Validation in WP-CLI framework
 link:      https://github.com/wp-cli/wp-cli/security/advisories/GHSA-rwgm-f83r-v3qj
 cve:       CVE-2021-29504
 reference: composer://wp-cli/wp-cli


### PR DESCRIPTION
Only after the change in #567 was merged  I noticed that I had copied the title from the upstream vulnerability, instead of the one that was fixed directly in the `wp-cli/wp-cli` package.

This PR fixes the title to match the GitHub adivsory.