### PR TITLE
Add CVE-2021-23420 in codeception/codeception

### DIFF
--- a/codeception/codeception/CVE-2021-23420.yaml
+++ b/codeception/codeception/CVE-2021-23420.yaml
@@ -1,0 +1,14 @@
+title:     Deserialization of Untrusted Data
+link:      https://github.com/advisories/GHSA-4574-qv3w-fcmg
+cve:       CVE-2021-23420
+branches:
+    "4.1":
+        time:     2021-08-06 17:20:00
+        versions: ['>=4.1.0', '<4.1.22']
+    "4.0":
+        time:     ~
+        versions: ['>=4.0.0', '<4.1.0']
+    "3.1":
+        time:     2021-08-06 17:20:00
+        versions: ['<3.1.3']
+reference: composer://codeception/codeception


### PR DESCRIPTION
See:
* https://github.com/advisories/GHSA-4574-qv3w-fcmg
* https://nvd.nist.gov/vuln/detail/CVE-2021-23420

Again, this is untested, as I still haven't found a way to test these with a local repository