### PR TITLE
Add CVE-2021-41106 for lcobucci/jwt

### DIFF
--- a/lcobucci/jwt/CVE-2021-41106.yaml
+++ b/lcobucci/jwt/CVE-2021-41106.yaml
@@ -1,0 +1,14 @@
+title:     "CVE-2021-41106: File reference keys leads to incorrect hashes on HMAC algorithms"
+link:      https://github.com/lcobucci/jwt/security/advisories/GHSA-7322-jrq4-x5hf
+cve:       2021-09-28T19:36:49Z
+branches:
+    3.4.x:
+        time:     2021-09-28 19:36:49
+        versions: ['>=3.4.0','<3.4.6']
+    4.0.x:
+        time:     2021-09-28 19:36:49
+        versions: ['>=4.0.0', '<4.0.4']
+    4.1.x:
+        time:     2021-09-28 19:36:49
+        versions: ['>=4.1.0', '<4.1.5']
+reference: composer://lcobucci/jwt

--- a/lcobucci/jwt/CVE-2021-41106.yaml
+++ b/lcobucci/jwt/CVE-2021-41106.yaml
@@ -1,6 +1,6 @@
 title:     "CVE-2021-41106: File reference keys leads to incorrect hashes on HMAC algorithms"
 link:      https://github.com/lcobucci/jwt/security/advisories/GHSA-7322-jrq4-x5hf
-cve:       2021-09-28T19:36:49Z
+cve:       CVE-2021-41106
 branches:
     3.4.x:
         time:     2021-09-28 19:36:49


### PR DESCRIPTION
According to published Github security issue

Done via Github web interface, no checks have been run on my side.