### PR TITLE
Add CVE-2021-43676

### DIFF
--- a/matyhtf/framework/CVE-2021-43676.yaml
+++ b/matyhtf/framework/CVE-2021-43676.yaml
@@ -1,0 +1,8 @@
+title: Path manipulation
+link: https://github.com/advisories/GHSA-mh9j-v6mq-pfch
+cve: CVE-2021-43676
+reference: composer://matyhtf/framework
+branches:
+    master:
+        time: null
+        versions: [ '<=3.0.5' ]

--- a/matyhtf/framework/CVE-2021-43676.yaml
+++ b/matyhtf/framework/CVE-2021-43676.yaml
@@ -3,6 +3,6 @@ link: https://github.com/advisories/GHSA-mh9j-v6mq-pfch
 cve: CVE-2021-43676
 reference: composer://matyhtf/framework
 branches:
-    master:
+    3.0:
         time: null
         versions: [ '<=3.0.5' ]

--- a/matyhtf/framework/CVE-2021-43676.yaml
+++ b/matyhtf/framework/CVE-2021-43676.yaml
@@ -4,5 +4,5 @@ cve: CVE-2021-43676
 reference: composer://matyhtf/framework
 branches:
     '3.0':
-        time: null
-        versions: [ '<=3.0.5' ]
+        time: 2022-03-17 16:15:10
+        versions: [ '<3.0.6' ]

--- a/matyhtf/framework/CVE-2021-43676.yaml
+++ b/matyhtf/framework/CVE-2021-43676.yaml
@@ -3,6 +3,6 @@ link: https://github.com/advisories/GHSA-mh9j-v6mq-pfch
 cve: CVE-2021-43676
 reference: composer://matyhtf/framework
 branches:
-    3.0:
+    '3.0':
         time: null
         versions: [ '<=3.0.5' ]


### PR DESCRIPTION
See https://github.com/advisories/GHSA-mh9j-v6mq-pfch.

There is no fix yet so we might have to update the YAML later.