### PR TITLE
fix(CVE-2020-15094): remove incorrect branch

### DIFF
--- a/symfony/http-kernel/CVE-2020-15094.yaml
+++ b/symfony/http-kernel/CVE-2020-15094.yaml
@@ -2,9 +2,6 @@ title:     "CVE-2020-15094: Prevent RCE when calling untrusted remote with Cachi
 link:      https://symfony.com/cve-2020-15094
 cve:       CVE-2020-15094
 branches:
-    4.3.x:
-        time:     2020-09-02 08:00:00
-        versions: ['>=4.3.0', '<4.4.0']
     4.4.x:
         time:     2020-09-02 08:00:00
         versions: ['>=4.4.0', '<4.4.13']


### PR DESCRIPTION
All the advisories that I can find for this list `>= 4.4.0`, though the NIST posting says "below version 4.4.13" which could have been where this came from.

Anyway, from what I can see `4.3.x` isn't affected by this: https://github.com/advisories/GHSA-754h-5r27-7x3r & https://github.com/symfony/symfony/security/advisories/GHSA-754h-5r27-7x3r