### PR TITLE
Add CVE-2022-28368 for Dompdf

### DIFF
--- a/dompdf/dompdf/CVE-2022-28368.yaml
+++ b/dompdf/dompdf/CVE-2022-28368.yaml
@@ -1,0 +1,8 @@
+title:     Remote code injection via remote fonts
+link:      https://github.com/advisories/GHSA-x752-qjv4-c4hc
+cve:       CVE-2022-28368
+branches:
+    master:
+        time:     2022-03-24 13:59:00
+        versions: ['<1.2.1']
+reference: composer://dompdf/dompdf


### PR DESCRIPTION
Creating this manually kind of sucks.

Can we somehow import all Github security advisories like https://github.com/advisories/GHSA-x752-qjv4-c4hc for PHP composer projects automatically? https://github.com/advisories?query=type%3Areviewed+ecosystem%3Acomposer