### PR TITLE
Accept main as a branch name

### DIFF
--- a/validator.php
+++ b/validator.php
@@ -161,7 +161,7 @@ final class Validate extends Command
                 $upperBoundWithoutLowerBound = null;
 
                 foreach ($data['branches'] as $name => $branch) {
-                    if (!preg_match('/^([\d.\-]+(\.x)?(-dev)?|master)$/', $name)) {
+                    if (!preg_match('/^([\d.\-]+(\.x)?(-dev)?|master|main)$/', $name)) {
                         $messages[$path][] = sprintf('Invalid branch name "%s".', $name);
                     }
 


### PR DESCRIPTION
The validator accepts `master`. With the new git default being `main`, I think we should accept it (see #633 for a usage of it).

What do you think @fabpot @naderman ?