### PR TITLE
Drupal core - Critical - Arbitrary PHP code execution - SA-CORE-2022-014

### DIFF
--- a/drupal/core/CVE-2022-25275.yaml
+++ b/drupal/core/CVE-2022-25275.yaml
@@ -1,0 +1,26 @@
+title: Drupal core - Moderately critical - Information Disclosure - SA-CORE-2022-012
+link: https://www.drupal.org/sa-core-2022-012
+cve: CVE-2022-25275
+branches:
+    7.x:
+        time:     2022-07-20 18:00:00
+        versions: [ '>=7.0.0','<7.91.0' ]
+    8.9.x:
+        time:     2022-07-20 18:00:00
+        versions: [ '>=8.9.0','<8.10.0' ]
+    9.0.x:
+        time:     2022-07-20 18:00:00
+        versions: ['>=9.0.0','<9.1.0']
+    9.1.x:
+        time:     2022-07-20 18:00:00
+        versions: ['>=9.1.0','<9.2.0']
+    9.2.x:
+        time:     2022-07-20 18:00:00
+        versions: ['>=9.2.0','<9.3.0']
+    9.3.x:
+        time:     2022-07-20 18:00:00
+        versions: ['>=9.3.0','<9.3.19']
+    9.4.x:
+        time:     2022-07-20 18:00:00
+        versions: [ '>=9.4.0','<9.4.3']
+reference: composer://drupal/core

--- a/drupal/core/CVE-2022-25277.yaml
+++ b/drupal/core/CVE-2022-25277.yaml
@@ -1,0 +1,23 @@
+title: Drupal core - Critical - Arbitrary PHP code execution - SA-CORE-2022-014
+link: https://www.drupal.org/sa-core-2022-014
+cve: CVE-2022-25277
+branches:
+    8.9.x:
+        time:     2022-07-20 18:00:00
+        versions: ['>=8.9.0','<8.10.0']
+    9.0.x:
+        time:     2022-07-20 18:00:00
+        versions: ['>=9.0.0','<9.1.0']
+    9.1.x:
+        time:     2022-07-20 18:00:00
+        versions: ['>=9.1.0','<9.2.0']
+    9.2.x:
+        time:     2022-07-20 18:00:00
+        versions: ['>=9.2.0','<9.3.0']
+    9.3.x:
+        time:     2022-07-20 18:00:00
+        versions: ['>=9.3.0','<9.3.19']
+    9.4.x:
+        time:     2022-07-20 18:00:00
+        versions: [ '>=9.4.0','<9.4.3']
+reference: composer://drupal/core


### PR DESCRIPTION
https://www.drupal.org/sa-core-2022-014

I see that a lot of security advisories were missing, but I just added the most recent. Also marked the last 8.9 branch + 9.0/9.1/9.2 as insecure because they are no longer covered in the security process. Combined with https://github.com/FriendsOfPHP/security-advisories/blob/master/drupal/core/CVE-2021-33829.yaml that should only keep 9.3.19 and 9.4.3 als secure options.