### PR TITLE
Add CVE-2022-35943 codeigniter4/shield

### DIFF
--- a/codeigniter4/shield/CVE-2022-35943.yaml
+++ b/codeigniter4/shield/CVE-2022-35943.yaml
@@ -1,0 +1,8 @@
+title:     "CVE-2022-35943: SameSite Attackers may Bypass the CSRF Protection"
+link:      https://github.com/codeigniter4/shield/security/advisories/GHSA-5hm8-vh6r-2cjq
+cve:       CVE-2022-35943
+branches:
+    master:
+        time:     2022-08-07 15:20:07
+        versions: ['<1.0.0-beta.2']
+reference: composer://codeigniter4/shield


### PR DESCRIPTION
I got the error:
> Version constraint "<1.0.0-beta.2" is not in an acceptable format.

Don't you accept advisories for pre-releases?
