### PR TITLE
Update advisory for CVE-2022-44543 in in2code/femanager

### DIFF
--- a/in2code/femanager/CVE-2022-44543.yaml
+++ b/in2code/femanager/CVE-2022-44543.yaml
@@ -7,5 +7,8 @@ branches:
         versions: ['>=7.0.0', '<7.0.1']
     6.x:
         time: '2022-11-02 11:59:00'
-        versions: ['<6.3.3']
+        versions: ['>=6.0.0', '<6.3.3']
+    5.x:
+        time: '2022-11-02 19:59:00'
+        versions: ['<5.5.2']
 reference: 'composer://in2code/femanager'


### PR DESCRIPTION
The extension maintainer released an additional version for websites running TYPO3 ELTS