### PR TITLE
Update CVE-2022-44543.yaml

### DIFF
--- a/in2code/femanager/CVE-2022-44543.yaml
+++ b/in2code/femanager/CVE-2022-44543.yaml
@@ -8,4 +8,7 @@ branches:
     6.x:
         time: '2022-11-02 11:59:00'
         versions: ['<6.3.3']
+    5.x:
+        time: '2022-11-02 20:00:00'
+        versions: ['<5.5.2']
 reference: 'composer://in2code/femanager'


### PR DESCRIPTION
The fix for TYPO3-EXT-SA-2022-015 was backported to the v5 branch and released as 5.5.2: in2code-de/femanager@166ea21