### PR TITLE
Add CVE-2022-42949 for silverstripe/subsites

### DIFF
--- a/silverstripe/subsites/CVE-2022-42949.yaml
+++ b/silverstripe/subsites/CVE-2022-42949.yaml
@@ -1,0 +1,8 @@
+title: 'CVE-2022-42949 - Subsite weakens file permissions'
+link: https://www.silverstripe.org/download/security-releases/cve-2022-42949
+cve: CVE-2022-42949
+branches:
+    2.0.x:
+        time: 2022-12-18 22:37:00
+        versions: ['>=2.0.0', '<2.6.1']
+reference: composer://silverstripe/subsites


### PR DESCRIPTION
Add notice for [CVE-2022-42949](https://www.silverstripe.org/download/security-releases/cve-2022-42949) on silverstripe/subsites