### PR TITLE
CVE-2023-27560

### DIFF
--- a/phpseclib/phpseclib/CVE-2023-27560.yaml
+++ b/phpseclib/phpseclib/CVE-2023-27560.yaml
@@ -1,0 +1,8 @@
+title:     Infinite Loop vulnerability
+link:      https://github.com/advisories/GHSA-hm7p-r324-hhf3
+cve:       CVE-2023-27560
+branches:
+    "3.0":
+        time:     2023-03-06 09:20:00
+        versions: ['>=3.0.0', '<3.0.19']
+reference: composer://phpseclib/phpseclib


### PR DESCRIPTION
One more missing CVE which I was able to catch, not sure how many are not in this repo.

I'm in doubts if symfony's security checker is safe to use with production-ready apps, since looks like everyone migrates to use github's advisories. IMO this repository should be abandoned in favor of https://github.com/advisories/ and so security checker.

Edit: meanwhile I'm migrating to `composer audit`