### PR TITLE
dompdf/dompdf CVE-2023-23924

### DIFF
--- a/dompdf/dompdf/CVE-2023-23924.yaml
+++ b/dompdf/dompdf/CVE-2023-23924.yaml
@@ -1,0 +1,8 @@
+title:     Dompdf vulnerable to URI validation failure on SVG parsing
+link:      https://github.com/advisories/GHSA-3cw5-7cxw-v5qg
+cve:       CVE-2023-23924
+branches:
+    master:
+        time:     2023-01-31 14:30:00
+        versions: ['<2.0.2']
+reference: composer://dompdf/dompdf


### PR DESCRIPTION
This vulnerability is a bit older, but it seems to be missing in this database.