### PR TITLE
Add CVE-2023-28104 for silverstripe/graphql

### DIFF
--- a/silverstripe/graphql/CVE-2023-28104.yaml
+++ b/silverstripe/graphql/CVE-2023-28104.yaml
@@ -1,0 +1,11 @@
+title:     "CVE-2023-28104 DDOS attack on graphql endpoints"
+link:      https://www.silverstripe.org/download/security-releases/CVE-2023-28104
+cve:       CVE-2023-28104
+branches:
+    4.1.x:
+        time:     2023-03-15 22:19:49
+        versions: ['>=4.1.1', '<4.1.2']
+    4.2.x:
+        time:     2023-03-15 22:21:49
+        versions: ['>=4.2.2', '<4.2.3']
+reference: composer://silverstripe/graphql


### PR DESCRIPTION
Originally had versions as `['4.1.1']` and `['4.2.2']` as only those exact versions are affected - but validation requires me to use `['>=a.b.c', '<x.y.z']` syntax.