### PR TITLE
Add Silverstripe CMS advisories SS-2023-002 and CVE-2023-32302

### DIFF
--- a/silverstripe/admin/SS-2023-002.yaml
+++ b/silverstripe/admin/SS-2023-002.yaml
@@ -1,0 +1,8 @@
+title:     "SS-2023-002 - Cross-site scripting (XSS) vulnerabilities inherited form TinyMCE"
+link:      https://www.silverstripe.org/download/security-releases/SS-2023-002
+cve:       ~
+branches:
+    1.13.x:
+        time:     2023-07-30 23:41:51
+        versions: ['>=1.0.0', '<1.13.6']
+reference: composer://silverstripe/admin

--- a/silverstripe/framework/CVE-2023-32302.yaml
+++ b/silverstripe/framework/CVE-2023-32302.yaml
@@ -1,0 +1,11 @@
+title:     "CVE-2023-32302 - Members with no password can be created and bypass custom login forms"
+link:      https://www.silverstripe.org/download/security-releases/CVE-2023-32302
+cve:       CVE-2023-32302
+branches:
+    4.13.x:
+        time:     2023-07-30 23:39:57
+        versions: ['>=3.0.0', '<4.13.14']
+    5.0.x:
+        time:     2023-07-31 00:15:08
+        versions: ['>=5.0.0', '<5.0.13']
+reference: composer://silverstripe/framework


### PR DESCRIPTION
Adding two recently patched advisories for Silverstripe CMS.