### PR TITLE
Add CVE-2023-40180 for silverstripe/graphql

### DIFF
--- a/silverstripe/graphql/CVE-2023-40180.yaml
+++ b/silverstripe/graphql/CVE-2023-40180.yaml
@@ -1,0 +1,20 @@
+title:     "CVE-2023-40180 DDOS Vulnerability on GraphQL due to lack of protection against recursive queries"
+link:      https://www.silverstripe.org/download/security-releases/CVE-2023-40180
+cve:       CVE-2023-40180
+branches:
+    3.8.x:
+        time:     2023-10-16 00:44:54
+        versions: ['>=3.0.0', '<3.8.2']
+    4.1.x:
+        time:     2023-10-16 00:45:17
+        versions: ['>=4.0.0', '<4.1.3']
+    4.2.x:
+        time:     2023-10-16 00:48:27
+        versions: ['>=4.2.0', '<4.2.5']
+    4.3.x:
+        time:     2023-10-16 00:50:20
+        versions: ['>=4.3.0', '<4.3.4']
+    5.0.x:
+        time:     2023-10-16 00:50:45
+        versions: ['>=5.0.0', '<5.0.3']
+reference: composer://silverstripe/graphql


### PR DESCRIPTION
Advisories:
- https://www.silverstripe.org/download/security-releases/cve-2023-40180
- https://github.com/silverstripe/silverstripe-graphql/security/advisories/GHSA-v23w-pppm-jh66

Relevant releases:
- https://github.com/silverstripe/silverstripe-graphql/releases/tag/3.8.2
- https://github.com/silverstripe/silverstripe-graphql/releases/tag/4.1.3
- https://github.com/silverstripe/silverstripe-graphql/releases/tag/4.2.5
- https://github.com/silverstripe/silverstripe-graphql/releases/tag/4.3.4
- https://github.com/silverstripe/silverstripe-graphql/releases/tag/5.0.3