### PR TITLE
 Add CVE-2022-48614 for mediawiki/semantic-media-wiki 

### DIFF
--- a/mediawiki/semantic-media-wiki/CVE-2022-48614.yaml
+++ b/mediawiki/semantic-media-wiki/CVE-2022-48614.yaml
@@ -1,0 +1,7 @@
+title: 'Cross-site Scripting in Semantic MediaWiki'
+link: 'https://nvd.nist.gov/vuln/detail/CVE-2022-48614'
+cve: CVE-2022-48614
+branches:
+    4.x:
+        versions: ['<4.0.2']
+reference: 'composer://mediawiki/semantic-media-wiki'

--- a/mediawiki/semantic-media-wiki/CVE-2022-48614.yaml
+++ b/mediawiki/semantic-media-wiki/CVE-2022-48614.yaml
@@ -3,5 +3,6 @@ link: 'https://nvd.nist.gov/vuln/detail/CVE-2022-48614'
 cve: CVE-2022-48614
 branches:
     4.x:
+        time: 2022-07-21 19:09:00
         versions: ['<4.0.2']
 reference: 'composer://mediawiki/semantic-media-wiki'


### PR DESCRIPTION
Reference: https://nvd.nist.gov/vuln/detail/CVE-2022-48614