### PR TITLE
CVE-2023-49316

### DIFF
--- a/phpseclib/phpseclib/CVE-2023-49316.yaml
+++ b/phpseclib/phpseclib/CVE-2023-49316.yaml
@@ -1,0 +1,8 @@
+title:     phpseclib vulnerable to denial of service 
+link:      https://github.com/advisories/GHSA-jpr7-q523-hx25
+cve:       CVE-2023-49316
+branches:
+    "3.0":
+        time:     2023-11-27 18:31:14
+        versions: ['>=3.0.0', '<3.0.34']
+reference: composer://phpseclib/phpseclib


### PR DESCRIPTION
`composer audit` found more security vulnerability advisory than the local checker. This is to add CVE-2023-49316 to this repository.

Since this is my first contribution to this repository, I copied [CVE-2023-27560.yaml](https://github.com/FriendsOfPHP/security-advisories/blob/master/phpseclib/phpseclib/CVE-2023-27560.yaml) and hope that I did all the necessary changes.