### PR TITLE
Add CVE details for January Silverstripe CMS patches

### DIFF
--- a/silverstripe/admin/CVE-2023-49783.yaml
+++ b/silverstripe/admin/CVE-2023-49783.yaml
@@ -1,0 +1,11 @@
+title:     "CVE-2023-49783 No permission checks for editing or deleting records with CSV import form"
+link:      https://www.silverstripe.org/download/security-releases/CVE-2023-49783
+cve:       CVE-2023-49783
+branches:
+    1.13.x:
+        time:     2024-01-23 03:15:01
+        versions: ['>=1.0.0', '<1.13.19']
+    2.1.x:
+        time:     2024-01-23 03:15:49
+        versions: ['>=2.0.0', '<2.1.8']
+reference: composer://silverstripe/admin

--- a/silverstripe/framework/CVE-2023-48714.yaml
+++ b/silverstripe/framework/CVE-2023-48714.yaml
@@ -1,0 +1,14 @@
+title:     "CVE-2023-48714 Record titles for restricted records can be viewed if exposed by GridFieldAddExistingAutocompleter"
+link:      https://www.silverstripe.org/download/security-releases/CVE-2023-48714
+cve:       CVE-2023-48714
+branches:
+    3.x:
+        time:     null
+        versions: ['>=3.0.0', '<4.0.0']
+    4.13.x:
+        time:     2024-01-22 22:46:28
+        versions: ['>=4.0.0', '<4.13.39']
+    5.1.x:
+        time:     2024-01-22 22:58:52
+        versions: ['>=5.0.0', '<5.1.11']
+reference: composer://silverstripe/framework

--- a/silverstripe/graphql/CVE-2023-44401.yaml
+++ b/silverstripe/graphql/CVE-2023-44401.yaml
@@ -1,0 +1,11 @@
+title:     "CVE-2023-44401 View permissions are bypassed for paginated lists of ORM data in GraphQL queries"
+link:      https://www.silverstripe.org/download/security-releases/CVE-2023-44401
+cve:       CVE-2023-44401
+branches:
+    4.3.x:
+        time:     2024-01-22 23:19:50
+        versions: ['>=4.0.0', '<4.3.7']
+    5.1.x:
+        time:     2024-01-22 23:26:08
+        versions: ['>=5.0.0', '<5.1.3']
+reference: composer://silverstripe/graphql


### PR DESCRIPTION
## Advisories

### `CVE-2023-49783`

- https://www.silverstripe.org/download/security-releases/cve-2023-49783/
- https://github.com/silverstripe/silverstripe-admin/security/advisories/GHSA-j3m6-gvm8-mhvw

### `CVE-2023-48714`

- https://www.silverstripe.org/download/security-releases/cve-2023-48714/
- https://github.com/silverstripe/silverstripe-framework/security/advisories/GHSA-qm2j-qvq3-j29v

### `CVE-2023-44401`

- https://www.silverstripe.org/download/security-releases/cve-2023-44401/
- https://github.com/silverstripe/silverstripe-graphql/security/advisories/GHSA-jgph-w8rh-xf5p

## Releases
Note that while the silverstripe/silverstripe-framework releases linked below have commits that are related to `CVE-2023-49783`, that repository is not in any way affected (from a vulnerability or exploitability standpoint) by the CVE, and so the CVE isn't relevant for that repository for the purposes of this PR. Those commits were only needed to resolve the vulnerability for silverstripe/silverstripe-admin.

### `CVE-2023-49783`

- https://github.com/silverstripe/silverstripe-admin/releases/tag/2.1.8
- https://github.com/silverstripe/silverstripe-admin/releases/tag/1.13.19

### `CVE-2023-48714`

- https://github.com/silverstripe/silverstripe-framework/releases/tag/5.1.11
- https://github.com/silverstripe/silverstripe-framework/releases/tag/4.13.39

### `CVE-2023-44401`

- https://github.com/silverstripe/silverstripe-graphql/releases/tag/5.1.3
- https://github.com/silverstripe/silverstripe-graphql/releases/tag/4.3.7