### PR TITLE
Updated links about jwt critical vulnerability

### DIFF
--- a/firebase/php-jwt/2015-04-02.yaml
+++ b/firebase/php-jwt/2015-04-02.yaml
@@ -1,5 +1,5 @@
 title:     Critical vulnerabilities in JSON Web Token libraries
-link:      https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+link:      https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
 cve:       ~
 branches:
     master:

--- a/gree/jose/2016-08-30.yaml
+++ b/gree/jose/2016-08-30.yaml
@@ -1,8 +1,8 @@
 title: Critical vulnerabilities in JSON Web Token libraries
-link: https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+link: https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
 cve: ~
 branches:
-  master: 
+  master:
     time: 2016-08-30 10:37:36
     versions: [<=2.2.0]
 reference: composer://gree/jose

--- a/namshi/jose/2015-03-10.yaml
+++ b/namshi/jose/2015-03-10.yaml
@@ -1,5 +1,5 @@
 title:     Critical vulnerabilities in JSON Web Token libraries
-link:      https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+link:      https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
 cve:       ~
 branches:
     master:


### PR DESCRIPTION
It's a minor improvement: but the reported url for "Critical vulnerabilities in JSON Web Token libraries" is changed