### PR TITLE
Refactor affected versions in CVE-2022-23601 to make the fix version more explicit

### DIFF
--- a/symfony/framework-bundle/CVE-2022-23601.yaml
+++ b/symfony/framework-bundle/CVE-2022-23601.yaml
@@ -4,11 +4,11 @@ cve:       CVE-2022-23601
 branches:
     5.3.x:
         time:     2022-01-29 12:00:00
-        versions: ['>=5.3.14', '<=5.3.14']
+        versions: ['>=5.3.14', '<5.3.15']
     5.4.x:
         time:     2022-01-29 12:00:00
-        versions: ['>=5.4.3', '<=5.4.3']
+        versions: ['>=5.4.3', '<5.4.4']
     6.0.x:
         time:     2022-01-29 12:00:00
-        versions: ['>=6.0.3', '<=6.0.3']
+        versions: ['>=6.0.3', '<6.0.4']
 reference: composer://symfony/framework-bundle

--- a/symfony/symfony/CVE-2022-23601.yaml
+++ b/symfony/symfony/CVE-2022-23601.yaml
@@ -5,11 +5,11 @@ cve:       CVE-2022-23601
 branches:
     5.3.x:
         time:     2022-01-29 12:00:00
-        versions: ['>=5.3.14', '<=5.3.14']
+        versions: ['>=5.3.14', '<5.3.15']
     5.4.x:
         time:     2022-01-29 12:00:00
-        versions: ['>=5.4.3', '<=5.4.3']
+        versions: ['>=5.4.3', '<5.4.4']
     6.0.x:
         time:     2022-01-29 12:00:00
-        versions: ['>=6.0.3', '<=6.0.3']
+        versions: ['>=6.0.3', '<6.0.4']
 reference: composer://symfony/symfony


### PR DESCRIPTION
Hi team,

This PR aims to keep the same information related to the vuln CVE-2022-23601, but to format it in a way that makes the fix version more explicit, as according to other sources:

- https://github.com/advisories/GHSA-vvmr-8829-6whx
- https://symfony.com/blog/cve-2022-23601-csrf-token-missing-in-forms

Thanks