### PR TITLE
Add mdanter/ecc

### DIFF
--- a/mdanter/ecc/2024-04-24.yaml
+++ b/mdanter/ecc/2024-04-24.yaml
@@ -1,0 +1,11 @@
+title:     Cryptographic side-channels in PHPECC
+link:      https://github.com/paragonie/phpecc/releases/tag/v2.0.0
+cve:       ~
+branches:
+    0.x:
+        time:     2024-04-24 00:00:00
+        versions: ['>=0', '<1']
+    1.x:
+        time:     2024-04-24 00:00:00
+        versions: ['>=1', '<2.0.0']
+reference: composer://mdanter/ecc


### PR DESCRIPTION
We've requested a CVE from MITRE. We will let you know when one is assigned.

References:

* https://github.com/paragonie/phpecc/releases/tag/v2.0.0
* https://github.com/phpecc/phpecc/issues/289#issuecomment-2074006410
