### PR TITLE
phpseclib/phpseclib CVE-2024-27354, CVE-2024-27355

### DIFF
--- a/phpseclib/phpseclib/CVE-2024-27354.yaml
+++ b/phpseclib/phpseclib/CVE-2024-27354.yaml
@@ -1,0 +1,14 @@
+title:     phpseclib a large prime can cause a denial of service
+link:      https://github.com/advisories/GHSA-hg35-mp25-qf6h
+cve:       CVE-2024-27354
+branches:
+    "3.0":
+        time:     2024-03-02 00:31:33
+        versions: ['>=3.0.0', '<3.0.36']
+    "2.0":
+        time:     2024-03-02 00:31:33
+        versions: ['>=2.0.0', '<2.0.47']
+    "1.0":
+        time:     2024-03-02 00:31:33
+        versions: ['>=1.0.0', '<1.0.23']
+reference: composer://phpseclib/phpseclib

--- a/phpseclib/phpseclib/CVE-2024-27355.yaml
+++ b/phpseclib/phpseclib/CVE-2024-27355.yaml
@@ -1,0 +1,14 @@
+title:     phpseclib does not properly limit the ASN1 OID length
+link:      https://github.com/advisories/GHSA-jr22-8qgm-4q87
+cve:       CVE-2024-27355
+branches:
+    "3.0":
+        time:     2024-03-02 00:31:33
+        versions: ['>=3.0.0', '<3.0.36']
+    "2.0":
+        time:     2024-03-02 00:31:33
+        versions: ['>=2.0.0', '<2.0.47']
+    "1.0":
+        time:     2024-03-02 00:31:33
+        versions: ['>=1.0.0', '<1.0.23']
+reference: composer://phpseclib/phpseclib


### PR DESCRIPTION
Add:
- CVE-2024-27354 https://github.com/advisories/GHSA-hg35-mp25-qf6h  
- CVE-2024-27355 https://github.com/advisories/GHSA-jr22-8qgm-4q87

Fixes: https://github.com/FriendsOfPHP/security-advisories/issues/720