### PR TITLE
mdanter/ecc security issue had a CVE id assigned

### DIFF
--- a/mdanter/ecc/CVE-2024-33851.yaml
+++ b/mdanter/ecc/CVE-2024-33851.yaml
@@ -1,6 +1,6 @@
 title:     Cryptographic side-channels in PHPECC
 link:      https://github.com/paragonie/phpecc/releases/tag/v2.0.0
-cve:       ~
+cve:       CVE-2024-33851
 branches:
     0.x:
         time:     2024-04-24 00:00:00


### PR DESCRIPTION
See https://github.com/FriendsOfPHP/security-advisories/pull/719#issuecomment-2081383336