### PR TITLE
Clean up mess around mdanter/ecc fork and CVE-2024-33851

### DIFF
--- a/mdanter/ecc/2024-04-24.yaml
+++ b/mdanter/ecc/2024-04-24.yaml
@@ -1,6 +1,6 @@
 title:     Cryptographic side-channels in PHPECC
 link:      https://github.com/paragonie/phpecc/releases/tag/v2.0.0
-cve:       CVE-2024-33851
+cve:       ~
 branches:
     0.x:
         time:     2024-04-24 00:00:00

--- a/mdanter/ecc/2024-04-24.yaml
+++ b/mdanter/ecc/2024-04-24.yaml
@@ -1,5 +1,5 @@
 title:     Cryptographic side-channels in PHPECC
-link:      https://github.com/paragonie/phpecc/releases/tag/v2.0.0
+link:      https://github.com/advisories/GHSA-346h-749j-r28w
 cve:       ~
 branches:
     0.x:

--- a/mdanter/ecc/CVE-2024-33851.yaml
+++ b/mdanter/ecc/CVE-2024-33851.yaml
@@ -1,0 +1,11 @@
+title:     mdanter/ecc affected by timing vulnerability in cryptographic side-channels
+link:      https://github.com/advisories/GHSA-3494-cfwf-56hw
+cve:       CVE-2024-33851
+branches:
+    0.x:
+        time:     2024-04-24 12:02:00
+        versions: ['>=0', '<1']
+    1.x:
+        time:     2024-04-24 12:02:00
+        versions: ['>=1', '<2.0.0']
+reference: composer://mdanter/ecc

--- a/paragonie/ecc/CVE-2024-33851.yaml
+++ b/paragonie/ecc/CVE-2024-33851.yaml
@@ -1,0 +1,8 @@
+title:     mdanter/ecc affected by timing vulnerability in cryptographic side-channels
+link:      https://github.com/advisories/GHSA-3494-cfwf-56hw
+cve:       CVE-2024-33851
+branches:
+    2.x:
+        time:     2024-04-24 12:02:00
+        versions: ['>=2', '<2.0.1']
+reference: composer://paragonie/ecc


### PR DESCRIPTION
Context:

https://github.com/FriendsOfPHP/security-advisories/pull/719 - multiple security issues in mdanter/ecc lead to fork in paragonie/ecc and I requested they fill in the CVE id when they have one. I then changed the advisory to include a CVE id in https://github.com/FriendsOfPHP/security-advisories/pull/722

However it turns out there are really two separate advisories:

- https://github.com/advisories/GHSA-346h-749j-r28w original broad issue leading the fork
- https://github.com/advisories/GHSA-3494-cfwf-56hw specific problem with CVE-2024-33851 which applies to mdanter/ecc but also new paragonie/ecc in version 2.0.0 only

So I've reverted the addition of the CVE id to the original advisory, and then added new advisories with the CVE id for the second issue on both packages now.