### PR TITLE
Add CVE-2024-34102 for Magento - Server-Side Request Forgery.

### DIFF
--- a/magento/product-community-edition/CVE-2024-34102.yaml
+++ b/magento/product-community-edition/CVE-2024-34102.yaml
@@ -1,4 +1,4 @@
-title:     Arbitrary Code Execution, Improper Restriction of XML External Entity Reference (XXE) vulnerability, Server Side Request Forgery
+title:     Arbitrary Code Execution through Improper Restriction of XML External Entity Reference (XXE) vulnerability
 link:      https://helpx.adobe.com/security/products/magento/apsb24-40.html
 cve:       CVE-2024-34102
 branches:

--- a/magento/product-community-edition/CVE-2024-34102.yaml
+++ b/magento/product-community-edition/CVE-2024-34102.yaml
@@ -1,0 +1,22 @@
+title:     Magento 2.4.7-p1, 2.4.6-p6, 2.4.5-p8 and 2.4.4-p9 Security update.
+link:      https://helpx.adobe.com/security/products/magento/apsb24-40.html
+cve:       CVE-2024-34102
+branches:
+    "2.4":
+        time: 2024-06-11 14:03:00
+        versions: [ '<2.4.4']
+    "2.4.4":
+        time:     2024-06-11 14:03:00
+        versions: ['>=2.4.4', '<2.4.4-p9']
+    "2.4.5":
+        time:     2024-06-11 14:04:00
+        versions: ['>=2.4.5', '<2.4.5-p8']
+    "2.4.6":
+        time:     2024-06-11 14:04:00
+        versions: ['>=2.4.6', '<2.4.6-p6']
+    "2.4.7":
+        time:     2024-06-11 14:05:00
+        versions: ['>=2.4.7', '<2.4.7-p1']
+
+reference: composer://magento/product-community-edition
+composer-repository: false

--- a/magento/product-community-edition/CVE-2024-34102.yaml
+++ b/magento/product-community-edition/CVE-2024-34102.yaml
@@ -1,4 +1,4 @@
-title:     Magento 2.4.7-p1, 2.4.6-p6, 2.4.5-p8 and 2.4.4-p9 Security update.
+title:     Arbitrary Code Execution, Improper Restriction of XML External Entity Reference (XXE) vulnerability, Server Side Request Forgery
 link:      https://helpx.adobe.com/security/products/magento/apsb24-40.html
 cve:       CVE-2024-34102
 branches:


### PR DESCRIPTION
This PR adds [CVE-2024-34102](https://nvd.nist.gov/vuln/detail/CVE-2024-34102). 

This CVE affects all versions of Magento prior to 2.4.4-p8. Magento versions prior to 2.4.4 are not maintained, there are therefore no fix deployed for those versions. 