### PR TITLE
Fix incorrect Affected versions for friendsofsymfony1/symfony1

### DIFF
--- a/friendsofsymfony1/symfony1/CVE-2024-28859.yaml
+++ b/friendsofsymfony1/symfony1/CVE-2024-28859.yaml
@@ -4,5 +4,5 @@ cve:       CVE-2024-28859
 branches:
     1.x:
         time:     2024-02-27 20:26:56
-        versions: ['>=1.3.0', '<1.15.18']
+        versions: ['>=1.3.0', '<1.5.18']
 reference: composer://friendsofsymfony1/symfony1

--- a/friendsofsymfony1/symfony1/CVE-2024-28861.yaml
+++ b/friendsofsymfony1/symfony1/CVE-2024-28861.yaml
@@ -4,5 +4,5 @@ cve:       CVE-2024-28861
 branches:
     1.x:
         time:     2024-03-19 13:59:00
-        versions: ['>=1.1.0', '<1.15.19']
+        versions: ['>=1.1.0', '<1.5.19']
 reference: composer://friendsofsymfony1/symfony1


### PR DESCRIPTION
The current version of [friendsofsymfony1/symfony1](https://github.com/FriendsOfSymfony1/symfony1) is 1.5.9, not 1.15.9. This causes issues with composer audit. Both existing CVEs are affected.