### PR TITLE
nategood/httpful: certificate verification issue

### DIFF
--- a/nategood/httpful/2024-05-01.yaml
+++ b/nategood/httpful/2024-05-01.yaml
@@ -1,0 +1,14 @@
+title:     Insecure HTTPS Connections due to Missing Default Certificate Validation
+link:      https://huntr.com/bounties/8d59c089-92f1-4b73-90f8-54968a70e2fb
+cve:       ~
+branches:
+    "0.1":
+        time:     2024-05-01 11:33:16
+        versions: [<0.2.0]
+    "0.2":
+        time:     2024-05-01 11:33:16
+        versions: ['>=0.2.0', '<0.3.0']
+    "0.3":
+        time:     2024-05-01 11:33:16
+        versions: ['>=0.3.0', '<1.0.0']
+reference: composer://nategood/httpful


### PR DESCRIPTION
A security issue has been disclosed for the `nategood/httpful` library, leaving all 0.x releases vulnerable. The author of the library has acknowledged the issue in the release notes of the 1.0.0 release:

https://github.com/nategood/httpful/blob/ea02c8aedef70b9a453ce97978d9d7c413972f15/README.md?plain=1#L68-L72