### PR TITLE
Add CVE details for January 2025 Silverstripe CMS patches

### DIFF
--- a/silverstripe/framework/CVE-2024-47605.yaml
+++ b/silverstripe/framework/CVE-2024-47605.yaml
@@ -1,0 +1,8 @@
+title:     "CVE-2024-47605 - XSS via insert media remote file oembed"
+link:      https://www.silverstripe.org/download/security-releases/cve-2024-47605
+cve:       CVE-2024-47605
+branches:
+    5.3.x:
+        time:     2025-01-14 21:24:19
+        versions: ['<5.3.8']
+reference: composer://silverstripe/framework

--- a/silverstripe/framework/CVE-2024-53277.yaml
+++ b/silverstripe/framework/CVE-2024-53277.yaml
@@ -1,0 +1,8 @@
+title:     "CVE-2024-53277 - XSS in form messages"
+link:      https://www.silverstripe.org/download/security-releases/cve-2024-53277
+cve:       CVE-2024-53277
+branches:
+    5.3.x:
+        time:     2025-01-14 21:24:36
+        versions: ['<5.3.8']
+reference: composer://silverstripe/framework

--- a/silverstripe/framework/SS-2024-002.yaml
+++ b/silverstripe/framework/SS-2024-002.yaml
@@ -1,0 +1,8 @@
+title:     "SS-2024-002 - Reflected Cross Site Scripting (XSS) in error message"
+link:      https://www.silverstripe.org/download/security-releases/ss-2024-002
+cve:       ~
+branches:
+    5.3.x:
+        time:     2025-01-14 21:23:51
+        versions: ['<5.3.8']
+reference: composer://silverstripe/framework


### PR DESCRIPTION
All of these were included in the 5.3.8 release: https://github.com/silverstripe/silverstripe-framework/releases/tag/5.3.8

## Advisories

### CVE-2024-47605

- https://www.silverstripe.org/download/security-releases/cve-2024-47605
- https://github.com/silverstripe/silverstripe-asset-admin/security/advisories/GHSA-7cmp-cgg8-4c82

### CVE-2024-53277

- https://www.silverstripe.org/download/security-releases/cve-2024-53277
- https://github.com/silverstripe/silverstripe-framework/security/advisories/GHSA-ff6q-3c9c-6cf5

### SS-2024-002

- https://www.silverstripe.org/download/security-releases/ss-2024-002
- https://github.com/silverstripe/silverstripe-framework/security/advisories/GHSA-mqf3-qpc3-g26q