### PR TITLE
Update CVE-2025-24856

### DIFF
--- a/causal/oidc/CVE-2025-24856.yaml
+++ b/causal/oidc/CVE-2025-24856.yaml
@@ -4,5 +4,5 @@ cve: CVE-2025-24856
 branches:
     main:
         time: 2025-01-27 18:56:00
-        versions: ['>=3.0.0', '<4.0.0']
+        versions: ['<4.0.0']
 reference: composer://causal/oidc


### PR DESCRIPTION
Updated CVE-2025-24856, because all versions below 4.0.0 are vulnerable.