### PR TITLE
Add unfixed vulnerabilities from Snyk

### DIFF
--- a/drupal-pattern-lab/add-attributes-twig-extension/2024-11-04.yaml
+++ b/drupal-pattern-lab/add-attributes-twig-extension/2024-11-04.yaml
@@ -1,0 +1,7 @@
+title: 'Cross-site Scripting (XSS)'
+link: 'https://security.snyk.io/vuln/SNYK-PHP-DRUPALPATTERNLABADDATTRIBUTESTWIGEXTENSION-8400879'
+branches:
+    master:
+        time: ~
+        versions: [ '>=0.0.0', '<=1.0.1' ]
+reference: 'composer://drupal-pattern-lab/add-attributes-twig-extension'

--- a/drupal-pattern-lab/bem-twig-extension/2024-11-04.yaml
+++ b/drupal-pattern-lab/bem-twig-extension/2024-11-04.yaml
@@ -1,0 +1,7 @@
+title: 'Cross-site Scripting (XSS)'
+link: 'https://security.snyk.io/vuln/SNYK-PHP-DRUPALPATTERNLABBEMTWIGEXTENSION-8400878'
+branches:
+    master:
+        time: ~
+        versions: [ '>=0.0.0', '<=1.0.1' ]
+reference: 'composer://drupal-pattern-lab/bem-twig-extension'

--- a/drupal-pattern-lab/unified-twig-extensions/2024-11-04.yaml
+++ b/drupal-pattern-lab/unified-twig-extensions/2024-11-04.yaml
@@ -1,0 +1,7 @@
+title: 'Cross-site Scripting (XSS)'
+link: 'https://security.snyk.io/vuln/SNYK-PHP-DRUPALPATTERNLABUNIFIEDTWIGEXTENSIONS-8400877'
+branches:
+    master:
+        time: ~
+        versions: [ '>=0.0.0', '<=0.1.0' ]
+reference: 'composer://drupal-pattern-lab/unified-twig-extensions'

--- a/j0k3r/httplug-ssrf-plugin/2024-11-04.yaml
+++ b/j0k3r/httplug-ssrf-plugin/2024-11-04.yaml
@@ -1,0 +1,7 @@
+title: 'Server-side Request Forgery (SSRF)'
+link: 'https://security.snyk.io/vuln/SNYK-PHP-J0K3RHTTPLUGSSRFPLUGIN-8400871'
+branches:
+    master:
+        time: ~
+        versions: [ '>=0.0.0', '<=3.0.1' ]
+reference: 'composer://j0k3r/httplug-ssrf-plugin'

--- a/pattern-lab/drupal-twig-components/2024-11-04.yaml
+++ b/pattern-lab/drupal-twig-components/2024-11-04.yaml
@@ -1,0 +1,7 @@
+title: 'Cross-site Scripting (XSS)'
+link: 'https://security.snyk.io/vuln/SNYK-PHP-PATTERNLABDRUPALTWIGCOMPONENTS-8400872'
+branches:
+    master:
+        time: ~
+        versions: [ '>=0.0.0', '<=2.2.0' ]
+reference: 'composer://pattern-lab/drupal-twig-components'


### PR DESCRIPTION
validator.php requires an upper bound but these vulnerabilities are unfixed.