### PR TITLE
Add CVE-2025-47964 for Symfony UX Twig/Live Component

### DIFF
--- a/symfony/ux-live-component/CVE-2025-47946.yaml
+++ b/symfony/ux-live-component/CVE-2025-47946.yaml
@@ -3,6 +3,6 @@ link:   https://symfony.com/blog/symfony-ux-cve-2025-47946-unsanitized-html-attr
 cve:    CVE-2025-47946
 branches:
     2.x:
-        time:       2025-05-19 14:05:00
+        time:       2025-05-19 12:05:00
         versions:   ['<2.25.1']
 reference: composer://symfony/ux-live-component

--- a/symfony/ux-live-component/CVE-2025-47946.yaml
+++ b/symfony/ux-live-component/CVE-2025-47946.yaml
@@ -1,0 +1,8 @@
+title:  "symfony/ux-live-component Unsanitized HTML attribute injection via ComponentAttributes"
+link:   https://symfony.com/blog/symfony-ux-cve-2025-47946-unsanitized-html-attribute-injection-via-componentattributes
+cve:    CVE-2025-47946
+branches:
+    2.x:
+        time:       2025-05-19 14:05:00
+        versions:   ['<2.25.1']
+reference: composer://symfony/ux-live-component

--- a/symfony/ux-twig-component/CVE-2025-47946.yaml
+++ b/symfony/ux-twig-component/CVE-2025-47946.yaml
@@ -1,0 +1,8 @@
+title:  "symfony/ux-twig-component Unsanitized HTML attribute injection via ComponentAttributes"
+link:   https://symfony.com/blog/symfony-ux-cve-2025-47946-unsanitized-html-attribute-injection-via-componentattributes
+cve:    CVE-2025-47946
+branches:
+    2.x:
+        time:       2025-05-19 14:05:00
+        versions:   ['<2.25.1']
+reference: composer://symfony/ux-twig-component

--- a/symfony/ux-twig-component/CVE-2025-47946.yaml
+++ b/symfony/ux-twig-component/CVE-2025-47946.yaml
@@ -3,6 +3,6 @@ link:   https://symfony.com/blog/symfony-ux-cve-2025-47946-unsanitized-html-attr
 cve:    CVE-2025-47946
 branches:
     2.x:
-        time:       2025-05-19 14:05:00
+        time:       2025-05-19 12:05:00
         versions:   ['<2.25.1']
 reference: composer://symfony/ux-twig-component


### PR DESCRIPTION
Related blog post: https://symfony.com/blog/symfony-ux-cve-2025-47946-unsanitized-html-attribute-injection-via-componentattributes