### PR TITLE
Add sodium_compat < 1.24, 2.5

### DIFF
--- a/paragonie/sodium_compat/2025-12-30.yaml
+++ b/paragonie/sodium_compat/2025-12-30.yaml
@@ -1,0 +1,11 @@
+title:     Missing check that a point is on the prime subgroup for Edwards25519
+link:      https://00f.net/2025/12/30/libsodium-vulnerability
+cve:       ~
+branches:
+    master:
+        time:     2025-12-30 00:00:00
+        versions: ['>=2', '<2.5.0']
+    1.x:
+        time:     2025-12-30 00:00:00
+        versions: ['<1.25.0']
+reference: composer://paragonie/sodium_compat

--- a/paragonie/sodium_compat/2025-12-30.yaml
+++ b/paragonie/sodium_compat/2025-12-30.yaml
@@ -7,5 +7,5 @@ branches:
         versions: ['>=2', '<2.5.0']
     1.x:
         time:     2025-12-30 00:00:00
-        versions: ['<1.25.0']
+        versions: ['<1.24.0']
 reference: composer://paragonie/sodium_compat


### PR DESCRIPTION
https://00f.net/2025/12/30/libsodium-vulnerability/

We confirmed the same issue in sodium_compat and released fixes this morning.

Also, WordPress ticket: https://core.trac.wordpress.org/ticket/64462