### PR TITLE
CVE id assigned for composer/composer GHSA-f9f8-rm49-7jv2: CVE-2026-45793

### DIFF
--- a/composer/composer/CVE-2026-45793.yaml
+++ b/composer/composer/CVE-2026-45793.yaml
@@ -1,6 +1,6 @@
 title:     Github Actions issued GITHUB_TOKEN disclosure in GitHub Actions logs
 link:      https://github.com/composer/composer/security/advisories/GHSA-f9f8-rm49-7jv2
-cve:       ~
+cve:       CVE-2026-45793
 branches:
     2.x:
         time:     2026-05-13 07:00:00


### PR DESCRIPTION
Renaming the file in line with repo guidelines to the CVE id, now that it has been assigned.