### PR TITLE
Added latest TYPO3 extension CVEs

### DIFF
--- a/evoweb/sf-register/CVE-2026-46721.yaml
+++ b/evoweb/sf-register/CVE-2026-46721.yaml
@@ -1,0 +1,11 @@
+title: 'TYPO3-EXT-SA-2026-009: Broken Access Control in extension "Frontend User Registration" (sf_register)'
+link: 'https://typo3.org/security/advisory/typo3-ext-sa-2026-009'
+cve: CVE-2026-46721
+branches:
+    14.x:
+        time: '2026-05-18 16:40:54'
+        versions: ['>=14.0.0', '<14.0.2']
+    13.x:
+        time: '2026-05-18 16:44:09'
+        versions: ['<13.2.4']
+reference: 'composer://evoweb/sf-register'

--- a/friendsoftypo3/tt-address/CVE-2026-8827.yaml
+++ b/friendsoftypo3/tt-address/CVE-2026-8827.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-012: SQL Injection in extension "Address List" (tt_address)'
+link: 'https://typo3.org/security/advisory/typo3-ext-sa-2026-012'
+cve: CVE-2026-8827
+branches:
+    10.x:
+        time: '2026-05-18 15:27:01'
+        versions: ['>=10.0.0', '<10.0.1']
+    9.x:
+        time: '2026-05-18 15:19:13'
+        versions: ['>=9.0.0', '<9.1.1']
+    8.x:
+        time: '2026-05-18 15:13:22'
+        versions: ['<8.1.2']
+reference: 'composer://friendsoftypo3/tt-address'

--- a/mmc/ceselector/CVE-2026-46725.yaml
+++ b/mmc/ceselector/CVE-2026-46725.yaml
@@ -1,0 +1,17 @@
+title: 'TYPO3-EXT-SA-2026-013: Remote Code Execution in extension "Content Element Selector" (ceselector)'
+link: 'https://typo3.org/security/advisory/typo3-ext-sa-2026-013'
+cve: CVE-2026-46725
+branches:
+    6.x:
+        time: '2026-04-07 10:50:50'
+        versions: ['>=6.0.0', '<6.0.1']
+    5.x:
+        time: '2026-04-09 22:34:39'
+        versions: ['>=5.0.0', '<5.0.1']
+    4.x:
+        time: '2026-04-09 22:15:11'
+        versions: ['>=4.0.0', '<4.0.2']
+    3.x:
+        time: '2026-04-09 21:39:03'
+        versions: ['<3.0.3']
+reference: 'composer://mmc/ceselector'

--- a/tomasnorre/crawler/CVE-2026-8727.yaml
+++ b/tomasnorre/crawler/CVE-2026-8727.yaml
@@ -1,0 +1,11 @@
+title: 'TYPO3-EXT-SA-2026-008: Remote Code Execution in extension "Site Crawler" (crawler)'
+link: 'https://typo3.org/security/advisory/typo3-ext-sa-2026-008'
+cve: CVE-2026-8727
+branches:
+    12.x:
+        time: '2026-05-11 19:18:44'
+        versions: ['>=12.0.0', '<12.0.11']
+    11.x:
+        time: '2026-05-18 17:48:41'
+        versions: ['<11.0.13']
+reference: 'composer://tomasnorre/crawler'

--- a/tpwd/ke_search/CVE-2026-46722.yaml
+++ b/tpwd/ke_search/CVE-2026-46722.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-011: XML External Entity Injection in extension "Faceted Search" (ke_search)'
+link: 'https://typo3.org/security/advisory/typo3-ext-sa-2026-011'
+cve: CVE-2026-46722
+branches:
+    7.x:
+        time: '2026-05-18 14:42:46'
+        versions: ['>=7.0.0', '<7.0.1']
+    6.x:
+        time: '2026-05-18 14:36:36'
+        versions: ['>=6.0.0', '<6.6.1']
+    5.x:
+        time: '2026-05-18 14:30:45'
+        versions: ['<5.6.2']
+reference: 'composer://tpwd/ke_search'

--- a/tpwd/ke_search/CVE-2026-46723.yaml
+++ b/tpwd/ke_search/CVE-2026-46723.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-011: Path Traversal in extension "Faceted Search" (ke_search)'
+link: 'https://typo3.org/security/advisory/typo3-ext-sa-2026-011'
+cve: CVE-2026-46723
+branches:
+    7.x:
+        time: '2026-05-18 14:42:46'
+        versions: ['>=7.0.0', '<7.0.1']
+    6.x:
+        time: '2026-05-18 14:36:36'
+        versions: ['>=6.0.0', '<6.6.1']
+    5.x:
+        time: '2026-05-18 14:30:45'
+        versions: ['<5.6.2']
+reference: 'composer://tpwd/ke_search'

--- a/tpwd/ke_search/CVE-2026-46724.yaml
+++ b/tpwd/ke_search/CVE-2026-46724.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-011: Information Disclosure in extension "Faceted Search" (ke_search)'
+link: 'https://typo3.org/security/advisory/typo3-ext-sa-2026-011'
+cve: CVE-2026-46724
+branches:
+    7.x:
+        time: '2026-05-18 14:42:46'
+        versions: ['>=7.0.0', '<7.0.1']
+    6.x:
+        time: '2026-05-18 14:36:36'
+        versions: ['>=6.0.0', '<6.6.1']
+    5.x:
+        time: '2026-05-18 14:30:45'
+        versions: ['<5.6.2']
+reference: 'composer://tpwd/ke_search'


### PR DESCRIPTION
This PR add the following CVEs:

**tomasnorre/crawler (Site Crawler)**
- CVE-2026-8727 - https://typo3.org/security/advisory/typo3-ext-sa-2026-008

**evoweb/sf-register (Frontend User Registration)**
- CVE-2026-46721 -  https://typo3.org/security/advisory/typo3-ext-sa-2026-009

**tpwd/ke_search (Faceted Search)**
- CVE-2026-46722 - https://typo3.org/security/advisory/typo3-ext-sa-2026-011
- CVE-2026-46723 - https://typo3.org/security/advisory/typo3-ext-sa-2026-011
- CVE-2026-46724 - https://typo3.org/security/advisory/typo3-ext-sa-2026-011

**friendsoftypo3/tt-address (Address List)**
- CVE-2026-8827 - https://typo3.org/security/advisory/typo3-ext-sa-2026-012

**mmc/ceselector (Content Element Selector)**
- CVE-2026-46725 - https://typo3.org/security/advisory/typo3-ext-sa-2026-013