### PR TITLE
Adjust version constraints for spatie/schema-org

### DIFF
--- a/spatie/schema-org/2026-04-20.yaml
+++ b/spatie/schema-org/2026-04-20.yaml
@@ -1,7 +1,10 @@
 title:     Cross-site scripting (XSS) via script break-out in toScript() output
 link:      https://github.com/spatie/schema-org/releases/tag/4.0.2
 branches:
+    3.x:
+        time:     2026-04-20 19:00:00
+        versions: ['>=3.23.1', '<3.23.2']
     main:
         time:     2026-04-20 19:00:00
-        versions: ['>=3.23.1,<3.23.2', '>=4.0.0,<4.0.2']
+        versions: ['>=4.0.0', '<4.0.2']
 reference: composer://spatie/schema-org

--- a/spatie/schema-org/2026-04-20.yaml
+++ b/spatie/schema-org/2026-04-20.yaml
@@ -3,5 +3,5 @@ link:      https://github.com/spatie/schema-org/releases/tag/4.0.2
 branches:
     main:
         time:     2026-04-20 19:00:00
-        versions: ['==3.23.1', '>=4.0.0', '<4.0.2']
-reference: composer://spatie/schema-org
+        versions: ['>=3.23.1,<3.23.2', '>=4.0.0,<4.0.2']
+        reference: composer://spatie/schema-org

--- a/spatie/schema-org/2026-04-20.yaml
+++ b/spatie/schema-org/2026-04-20.yaml
@@ -3,5 +3,5 @@ link:      https://github.com/spatie/schema-org/releases/tag/4.0.2
 branches:
     main:
         time:     2026-04-20 19:00:00
-        versions: ['3.23.1', '>=4.0.0', '<4.0.2']
+        versions: ['==3.23.1', '>=4.0.0', '<4.0.2']
 reference: composer://spatie/schema-org

--- a/spatie/schema-org/2026-04-20.yaml
+++ b/spatie/schema-org/2026-04-20.yaml
@@ -2,7 +2,7 @@ title:     Cross-site scripting (XSS) via script break-out in toScript() output
 link:      https://github.com/spatie/schema-org/releases/tag/4.0.2
 branches:
     3.x:
-        time:     2026-04-20 19:00:00
+        time:     2026-05-29 07:46:00
         versions: ['>=3.23.1', '<3.23.2']
     main:
         time:     2026-04-20 19:00:00

--- a/spatie/schema-org/2026-04-20.yaml
+++ b/spatie/schema-org/2026-04-20.yaml
@@ -4,4 +4,4 @@ branches:
     main:
         time:     2026-04-20 19:00:00
         versions: ['>=3.23.1,<3.23.2', '>=4.0.0,<4.0.2']
-        reference: composer://spatie/schema-org
+reference: composer://spatie/schema-org

--- a/spatie/schema-org/2026-04-20.yaml
+++ b/spatie/schema-org/2026-04-20.yaml
@@ -3,5 +3,5 @@ link:      https://github.com/spatie/schema-org/releases/tag/4.0.2
 branches:
     main:
         time:     2026-04-20 19:00:00
-        versions: ['>=3.23.1', '<4.0.2']
+        versions: ['3.23.1', '>=4.0.0', '<4.0.2']
 reference: composer://spatie/schema-org


### PR DESCRIPTION
There has been a https://github.com/spatie/schema-org/releases/tag/3.23.2 backport to fix the security issues for the 3.x branch. 

From the release notes:
> (affected: 3.23.1 through 4.0.1)