### PR TITLE
Improve validator performance

### DIFF
--- a/validator.php
+++ b/validator.php
@@ -31,6 +31,7 @@ final class Validate extends Command
 {
     private Parser $parser;
     private array $composerRepositories = array();
+    private array $composerPackageExists = array();
     private Config $composerConfig;
     private HttpDownloader $httpDownloader;
 
@@ -147,16 +148,7 @@ final class Validate extends Command
                         }
 
                         if (!empty($data['composer-repository'])) {
-                            $composerRepository = $this->getComposerRepository($data['composer-repository']);
-
-                            $found = false;
-                            foreach ($composerRepository->search($composerPackage, RepositoryInterface::SEARCH_NAME) as $package) {
-                                if ($package['name'] === $composerPackage) {
-                                    $found = true;
-                                    break;
-                                }
-                            }
-                            if (!$found) {
+                            if (!$this->composerPackageExists($data['composer-repository'], $composerPackage)) {
                                 $messages[$path][] = sprintf('Invalid composer package (not found in repository %s)', $data['composer-repository']);
                             }
                         }
@@ -300,6 +292,27 @@ final class Validate extends Command
         }
 
         return count($messages);
+    }
+
+    private function composerPackageExists(string $repositoryUri, string $package): bool
+    {
+        $key = $repositoryUri."\0".$package;
+
+        if (!isset($this->composerPackageExists[$key])) {
+            $repository = $this->getComposerRepository($repositoryUri);
+
+            $found = false;
+            foreach ($repository->search($package, RepositoryInterface::SEARCH_NAME) as $result) {
+                if ($result['name'] === $package) {
+                    $found = true;
+                    break;
+                }
+            }
+
+            $this->composerPackageExists[$key] = $found;
+        }
+
+        return $this->composerPackageExists[$key];
     }
 
     private function getComposerRepository($uri): ComposerRepository


### PR DESCRIPTION
When I recently added a new advisory to this repo, I run the `validator.php` script to ensure it's correct.

However, I found that it was a bit slow to run (~24 seconds). I see that the validator is making a network call to search on Packagist per advisory, instead of per package.

1,166 files in this repo trigger a network search, but they only represent 311 distinct packages, so we can avoid 73% of network calls with some memoization.

Performance comparation:

```bash
$ time php validator.php

Before:  23.92s user 3.69s system 98% cpu 28.027 total
After:    6.54s user 0.98s system 88% cpu  8.468 total
```