### PR TITLE
Add TYPO3 CVEs for the release on 2026-06-09

### DIFF
--- a/typo3/cms-core/CVE-2026-11607.yaml
+++ b/typo3/cms-core/CVE-2026-11607.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-CORE-SA-2026-019: Broken Access Control in Form Framework'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-019'
+cve: CVE-2026-11607
+branches:
+    10.x:
+        time: '2026-06-09 09:06:07'
+        versions: ['<10.4.57']
+    11.x:
+        time: '2026-06-09 09:06:07'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 09:06:07'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 09:06:07'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 09:06:07'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-47343.yaml
+++ b/typo3/cms-core/CVE-2026-47343.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-CORE-SA-2026-007: Broken Access Control in File Abstraction Layer'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-007'
+cve: CVE-2026-47343
+branches:
+    10.x:
+        time: '2026-06-09 08:55:42'
+        versions: ['<10.4.57']
+    11.x:
+        time: '2026-06-09 08:55:42'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 08:55:42'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 08:55:42'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 08:55:42'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-47346.yaml
+++ b/typo3/cms-core/CVE-2026-47346.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-CORE-SA-2026-008: Broken Access Control in Form Framework'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-008'
+cve: CVE-2026-47346
+branches:
+    10.x:
+        time: '2026-06-09 08:56:21'
+        versions: ['<10.4.57']
+    11.x:
+        time: '2026-06-09 08:56:21'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 08:56:21'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 08:56:21'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 08:56:21'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-47347.yaml
+++ b/typo3/cms-core/CVE-2026-47347.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-CORE-SA-2026-009: Open Redirect in TYPO3 CMS'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-009'
+cve: CVE-2026-47347
+branches:
+    10.x:
+        time: '2026-06-09 08:57:00'
+        versions: ['<10.4.57']
+    11.x:
+        time: '2026-06-09 08:57:00'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 08:57:00'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 08:57:00'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 08:57:00'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-47348.yaml
+++ b/typo3/cms-core/CVE-2026-47348.yaml
@@ -1,0 +1,11 @@
+title: 'TYPO3-CORE-SA-2026-010: Cross-Site Scripting in Indexed Search'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-010'
+cve: CVE-2026-47348
+branches:
+    13.x:
+        time: '2026-06-09 08:57:39'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 08:57:39'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-47349.yaml
+++ b/typo3/cms-core/CVE-2026-47349.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-CORE-SA-2026-011: Broken Access Control in Recycler'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-011'
+cve: CVE-2026-47349
+branches:
+    10.x:
+        time: '2026-06-09 08:58:19'
+        versions: ['<10.4.57']
+    11.x:
+        time: '2026-06-09 08:58:19'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 08:58:19'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 08:58:19'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 08:58:19'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-47350.yaml
+++ b/typo3/cms-core/CVE-2026-47350.yaml
@@ -1,0 +1,11 @@
+title: 'TYPO3-CORE-SA-2026-012: Broken Access Control in DataHandler'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-012'
+cve: CVE-2026-47350
+branches:
+    13.x:
+        time: '2026-06-09 08:58:58'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 08:58:58'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-47351.yaml
+++ b/typo3/cms-core/CVE-2026-47351.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-CORE-SA-2026-014: Broken Access Control in Clipboard'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-014'
+cve: CVE-2026-47351
+branches:
+    10.x:
+        time: '2026-06-09 09:00:20'
+        versions: ['<10.4.57']
+    11.x:
+        time: '2026-06-09 09:00:20'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 09:00:20'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 09:00:20'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 09:00:20'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-47352.yaml
+++ b/typo3/cms-core/CVE-2026-47352.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-CORE-SA-2026-015: Broken Access Control in Backend API'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-015'
+cve: CVE-2026-47352
+branches:
+    10.x:
+        time: '2026-06-09 09:01:04'
+        versions: ['<10.4.57']
+    11.x:
+        time: '2026-06-09 09:01:04'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 09:01:04'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 09:01:04'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 09:01:04'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-49738.yaml
+++ b/typo3/cms-core/CVE-2026-49738.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-CORE-SA-2026-016: Broken Access Control in File Abstraction Layer'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-016'
+cve: CVE-2026-49738
+branches:
+    10.x:
+        time: '2026-06-09 09:01:48'
+        versions: ['<10.4.57']
+    11.x:
+        time: '2026-06-09 09:01:48'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 09:01:48'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 09:01:48'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 09:01:48'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-49740.yaml
+++ b/typo3/cms-core/CVE-2026-49740.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-CORE-SA-2026-018: Insecure Deserialization in Core API'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-018'
+cve: CVE-2026-49740
+branches:
+    10.x:
+        time: '2026-06-09 09:03:02'
+        versions: ['<10.4.57']
+    11.x:
+        time: '2026-06-09 09:03:02'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 09:03:02'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 09:03:02'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 09:03:02'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-49741.yaml
+++ b/typo3/cms-core/CVE-2026-49741.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-CORE-SA-2026-017: Privilege Escalation &amp; SQL Injection in Form Framework'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-017'
+cve: CVE-2026-49741
+branches:
+    14.x:
+        time: '2026-06-09 09:02:19'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/cms-core/CVE-2026-49742.yaml
+++ b/typo3/cms-core/CVE-2026-49742.yaml
@@ -1,0 +1,17 @@
+title: 'TYPO3-CORE-SA-2026-013: Broken Access Control in Media Module'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-013'
+cve: CVE-2026-49742
+branches:
+    11.x:
+        time: '2026-06-09 08:59:35'
+        versions: ['>=11.0.0', '<11.5.51']
+    12.x:
+        time: '2026-06-09 08:59:35'
+        versions: ['>=12.0.0', '<12.4.46']
+    13.x:
+        time: '2026-06-09 08:59:35'
+        versions: ['>=13.0.0', '<13.4.31']
+    14.x:
+        time: '2026-06-09 08:59:35'
+        versions: ['>=14.0.0', '<14.3.3']
+reference: 'composer://typo3/cms-core'

--- a/typo3/html-sanitizer/CVE-2026-47344.yaml
+++ b/typo3/html-sanitizer/CVE-2026-47344.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-CORE-SA-2026-006: TYPO3 HTML Sanitizer allows Cross-Site Scripting'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-006'
+cve: CVE-2026-47344
+branches:
+    2.x:
+        time: '2026-06-08 20:00:00'
+        versions: ['<2.3.2']
+reference: 'composer://typo3/html-sanitizer'

--- a/typo3/html-sanitizer/CVE-2026-47345.yaml
+++ b/typo3/html-sanitizer/CVE-2026-47345.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-CORE-SA-2026-006: TYPO3 HTML Sanitizer allows Cross-Site Scripting'
+link: 'https://typo3.org/security/advisory/typo3-core-sa-2026-006'
+cve: CVE-2026-47345
+branches:
+    2.x:
+        time: '2026-06-08 20:00:00'
+        versions: ['<2.3.2']
+reference: 'composer://typo3/html-sanitizer'


### PR DESCRIPTION
https://news.typo3.com/article/typo3-1433-and-13431-security-releases-published https://news.typo3.com/article/typo3-10457-11551-and-12446-elts-released

The versions for 10.x, 11.x and 12.x are in ELTS mode, and not available in public on packagist.org anymore. The existence of those version can be verified in the corresponding release information at:

* https://get.typo3.org/list/version/10
* https://get.typo3.org/list/version/11
* https://get.typo3.org/list/version/12