### PR TITLE
Adding CVE-2026-54133 - mtdowling/jmespath.php

### DIFF
--- a/mtdowling/jmespath.php/CVE-2026-54133.yaml
+++ b/mtdowling/jmespath.php/CVE-2026-54133.yaml
@@ -1,0 +1,8 @@
+title: 'CompilerRuntime code injection via unescaped function names'
+link: 'https://github.com/jmespath/jmespath.php/security/advisories/GHSA-pcw8-m77r-2528'
+cve: CVE-2026-54133
+branches:
+    master:
+        versions: ['<2.9.1']
+        time: 2026-06-11 10:41:50
+reference: 'composer://mtdowling/jmespath.php'


### PR DESCRIPTION
First time contributor here, let me know if I did something wrong.

Adding this file since `composer audit` at the moment isn't outputting this security vulnerability.