### PR TITLE
Adding GHSA-g7m4-839x-ch6v & GHSA-2jx3-65f3-xr8r - spomky-labs/otphp

### DIFF
--- a/spomky-labs/otphp/GHSA-2jx3-65f3-xr8r.yaml
+++ b/spomky-labs/otphp/GHSA-2jx3-65f3-xr8r.yaml
@@ -1,0 +1,8 @@
+title: 'Mass-assignment in Factory::loadFromProvisioningUri lets a hostile provisioning URI corrupt OTP state or leak an uncaught TypeError'
+link: 'https://github.com/Spomky-Labs/otphp/security/advisories/GHSA-2jx3-65f3-xr8r'
+cve: ~
+branches:
+    11.x:
+        versions: ['<11.4.3']
+        time: 2026-05-31 09:08:33
+reference: 'composer://spomky-labs/otphp'

--- a/spomky-labs/otphp/GHSA-g7m4-839x-ch6v.yaml
+++ b/spomky-labs/otphp/GHSA-g7m4-839x-ch6v.yaml
@@ -1,0 +1,8 @@
+title: 'Unbounded digits parameter in a provisioning URI triggers an uncaught DivisionByZeroError in OTP generation'
+link: 'https://github.com/Spomky-Labs/otphp/security/advisories/GHSA-g7m4-839x-ch6v'
+cve: ~
+branches:
+    11.x:
+        versions: ['<11.4.3']
+        time: 2026-05-31 09:06:37
+reference: 'composer://spomky-labs/otphp'


### PR DESCRIPTION
First time contributor here, let me know if I did something wrong.
Not sure about branches format, since `11.x` isn't a real branch in the repository while `11.4.x`, `11.5.x` and `11.6.x` are. I'm guessing it should be treated more like a version constraint? Anyway, if this needs some tweaks, let me know.

Adding these files since `composer audit` at the moment isn't outputting these security vulnerabilities.