### PR TITLE
Adding GHSA-3prj-6hqw-cm82, GHSA-5739-39v2-5754, GHSA-6vvh-pxr4-25r7 …

### DIFF
--- a/web-token/jwt-framework/GHSA-3prj-6hqw-cm82.yaml
+++ b/web-token/jwt-framework/GHSA-3prj-6hqw-cm82.yaml
@@ -1,0 +1,14 @@
+title: 'PBES2-HS*+A*KW unwrap accepts an unbounded p2c iteration count, enabling CPU-amplification denial of service'
+link: 'https://github.com/web-token/jwt-framework/security/advisories/GHSA-3prj-6hqw-cm82'
+cve: ~
+branches:
+    3.x:
+        versions: ['<=3.4.9']
+        time: 2026-06-06 16:26:43
+    4.0.x:
+        versions: ['>=4.0.0', '<=4.0.6']
+        time: 2026-06-06 16:26:43
+    4.1.x:
+        versions: ['>=4.1.0', '<=4.1.6']
+        time: 2026-06-06 16:26:43
+reference: 'composer://web-token/jwt-framework'

--- a/web-token/jwt-framework/GHSA-5739-39v2-5754.yaml
+++ b/web-token/jwt-framework/GHSA-5739-39v2-5754.yaml
@@ -1,0 +1,14 @@
+title: 'RSA1_5 (RSAES-PKCS1-v1_5) decryption lacks implicit rejection, exposing a Bleichenbacher/Marvin padding oracle'
+link: 'https://github.com/web-token/jwt-framework/security/advisories/GHSA-5739-39v2-5754'
+cve: ~
+branches:
+    3.x:
+        versions: ['<=3.4.9']
+        time: 2026-06-06 16:27:24
+    4.0.x:
+        versions: ['>=4.0.0', '<=4.0.6']
+        time: 2026-06-06 16:27:24
+    4.1.x:
+        versions: ['>=4.1.0', '<=4.1.6']
+        time: 2026-06-06 16:27:24
+reference: 'composer://web-token/jwt-framework'

--- a/web-token/jwt-framework/GHSA-6vvh-pxr4-25r7.yaml
+++ b/web-token/jwt-framework/GHSA-6vvh-pxr4-25r7.yaml
@@ -1,0 +1,14 @@
+title: 'Chacha20Poly1305 key-encryption algorithm discards the Poly1305 authentication tag, performing no authentication on decryption'
+link: 'https://github.com/web-token/jwt-framework/security/advisories/GHSA-6vvh-pxr4-25r7'
+cve: ~
+branches:
+    3.x:
+        versions: ['<=3.4.9']
+        time: 2026-06-06 16:27:05
+    4.0.x:
+        versions: ['>=4.0.0', '<=4.0.6']
+        time: 2026-06-06 16:27:05
+    4.1.x:
+        versions: ['>=4.1.0', '<=4.1.6']
+        time: 2026-06-06 16:27:05
+reference: 'composer://web-token/jwt-framework'

--- a/web-token/jwt-framework/GHSA-jc38-x7x8-2xc8.yaml
+++ b/web-token/jwt-framework/GHSA-jc38-x7x8-2xc8.yaml
@@ -1,0 +1,14 @@
+title: 'JWSVerifier uses algorithm from unprotected header, enabling algorithm confusion attacks'
+link: 'https://github.com/web-token/jwt-framework/security/advisories/GHSA-jc38-x7x8-2xc8'
+cve: ~
+branches:
+    3.x:
+        versions: ['<=3.4.9']
+        time: 2026-06-06 16:30:13
+    4.0.x:
+        versions: ['>=4.0.0', '<=4.0.6']
+        time: 2026-06-06 16:30:13
+    4.1.x:
+        versions: ['>=4.1.0', '<=4.1.6']
+        time: 2026-06-06 16:30:13
+reference: 'composer://web-token/jwt-framework'

--- a/web-token/jwt-library/GHSA-3prj-6hqw-cm82.yaml
+++ b/web-token/jwt-library/GHSA-3prj-6hqw-cm82.yaml
@@ -11,4 +11,4 @@ branches:
     4.1.x:
         versions: ['>=4.1.0', '<4.1.7']
         time: 2026-06-06 16:26:43
-reference: 'composer://web-token/jwt-framework'
+reference: 'composer://web-token/jwt-library'

--- a/web-token/jwt-library/GHSA-5739-39v2-5754.yaml
+++ b/web-token/jwt-library/GHSA-5739-39v2-5754.yaml
@@ -11,4 +11,4 @@ branches:
     4.1.x:
         versions: ['>=4.1.0', '<4.1.7']
         time: 2026-06-06 16:27:24
-reference: 'composer://web-token/jwt-framework'
+reference: 'composer://web-token/jwt-library'

--- a/web-token/jwt-library/GHSA-6vvh-pxr4-25r7.yaml
+++ b/web-token/jwt-library/GHSA-6vvh-pxr4-25r7.yaml
@@ -11,4 +11,4 @@ branches:
     4.1.x:
         versions: ['>=4.1.0', '<4.1.7']
         time: 2026-06-06 16:27:05
-reference: 'composer://web-token/jwt-framework'
+reference: 'composer://web-token/jwt-library'

--- a/web-token/jwt-library/GHSA-jc38-x7x8-2xc8.yaml
+++ b/web-token/jwt-library/GHSA-jc38-x7x8-2xc8.yaml
@@ -11,4 +11,4 @@ branches:
     4.1.x:
         versions: ['>=4.1.0', '<4.1.7']
         time: 2026-06-06 16:30:13
-reference: 'composer://web-token/jwt-framework'
+reference: 'composer://web-token/jwt-library'


### PR DESCRIPTION
…& GHSA-jc38-x7x8-2xc8 - web-token/jwt-framework

First time contributor here, let me know if I did something wrong.
Not sure about branches format. Anyway, if this needs some tweaks, let me know.

Adding these files since `composer audit` at the moment isn't outputting these security vulnerabilities.