### PR TITLE
Add guzzlehttp/guzzle advisories and correct fix dates

### DIFF
--- a/guzzlehttp/guzzle/CVE-2016-5385.yaml
+++ b/guzzlehttp/guzzle/CVE-2016-5385.yaml
@@ -3,12 +3,12 @@ link:      https://github.com/guzzle/guzzle/releases/tag/6.2.1
 cve:       CVE-2016-5385
 branches:
     master:
-        time:     2015-07-15 17:14:23
+        time:     2016-07-18 14:09:08
         versions: ['>=6', '<6.2.1']
     4.x:
-        time:     2015-07-15 17:36:08
+        time:     2016-07-15 17:44:18
         versions: ['>=4.0.0-rc2', '<4.2.4']
     "5.3":
-        time:     2015-07-15 19:28:39
+        time:     2016-07-15 19:28:39
         versions: ['>=5', '<5.3.1']
 reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2022-29248.yaml
+++ b/guzzlehttp/guzzle/CVE-2022-29248.yaml
@@ -3,10 +3,10 @@ link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-cwmx-hcrq-m
 cve:       CVE-2022-29248
 branches:
     master:
-        time:     2022-05-25 13:24:00
+        time:     2022-05-25 13:24:33
         versions: ['>=7', '<7.4.3']
     '6.x':
-        time:     2022-05-25 13:21:00
+        time:     2022-05-25 13:19:12
         versions: ['>=4', '<6.5.6']
 
 reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2022-31042.yaml
+++ b/guzzlehttp/guzzle/CVE-2022-31042.yaml
@@ -3,10 +3,10 @@ link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-f2wf-25xc-6
 cve:       CVE-2022-31042
 branches:
     master:
-        time:     2022-06-09 23:39:00
+        time:     2022-06-09 21:39:15
         versions: ['>=7', '<7.4.4']
     '6.x':
-        time:     2022-06-09 23:36:00
+        time:     2022-06-09 21:36:50
         versions: ['>=4', '<6.5.7']
 
 reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2022-31043.yaml
+++ b/guzzlehttp/guzzle/CVE-2022-31043.yaml
@@ -3,10 +3,10 @@ link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-w248-ffj2-4
 cve:       CVE-2022-31043
 branches:
     master:
-        time:     2022-06-09 23:39:00
+        time:     2022-06-09 21:39:15
         versions: ['>=7', '<7.4.4']
     '6.x':
-        time:     2022-06-09 23:36:00
+        time:     2022-06-09 21:36:50
         versions: ['>=4', '<6.5.7']
 
 reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2022-31090.yaml
+++ b/guzzlehttp/guzzle/CVE-2022-31090.yaml
@@ -3,10 +3,10 @@ link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-25mq-v84q-4
 cve:       CVE-2022-31090
 branches:
     master:
-        time:     2022-06-20 22:24:00
+        time:     2022-06-20 22:16:13
         versions: ['>=7', '<7.4.5']
     '6.x':
-        time:     2022-06-20 22:24:00
+        time:     2022-06-20 22:16:07
         versions: ['>=4', '<6.5.8']
 
 reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2022-31091.yaml
+++ b/guzzlehttp/guzzle/CVE-2022-31091.yaml
@@ -3,10 +3,10 @@ link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-q559-8m2m-g
 cve:       CVE-2022-31091
 branches:
     master:
-        time:     2022-06-20 22:24:00
+        time:     2022-06-20 22:16:13
         versions: ['>=7', '<7.4.5']
     '6.x':
-        time:     2022-06-20 22:24:00
+        time:     2022-06-20 22:16:07
         versions: ['>=4', '<6.5.8']
 
 reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2026-55568.yaml
+++ b/guzzlehttp/guzzle/CVE-2026-55568.yaml
@@ -1,0 +1,9 @@
+title:     Silent HTTPS proxy downgrade to cleartext
+link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-wpwq-4j6v-78m3
+cve:       CVE-2026-55568
+branches:
+    '7.12':
+        time:     2026-06-18 14:12:49
+        versions: ['<7.12.1']
+
+reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2026-55767.yaml
+++ b/guzzlehttp/guzzle/CVE-2026-55767.yaml
@@ -1,0 +1,9 @@
+title:     Dot-only cookie domains match all hosts
+link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-cwxw-98qj-8qjx
+cve:       CVE-2026-55767
+branches:
+    '7.12':
+        time:     2026-06-18 14:12:49
+        versions: ['<7.12.1']
+
+reference: composer://guzzlehttp/guzzle


### PR DESCRIPTION
This adds two recently published advisories for guzzlehttp/guzzle, CVE-2026-55767 for dot-only cookie domains matching all hosts and CVE-2026-55568 for a silent HTTPS proxy downgrade to cleartext, both fixed in 7.12.1. It also corrects the fix dates on the existing guzzlehttp/guzzle entries to match the GitHub release creation timestamps, fixing the CVE-2016-5385 dates that had the wrong year and the CVE-2022-31042 and CVE-2022-31043 times that were two hours off.