### PR TITLE
Add guzzlehttp/psr7 advisories and correct fix dates

### DIFF
--- a/guzzlehttp/psr7/CVE-2022-24775.yaml
+++ b/guzzlehttp/psr7/CVE-2022-24775.yaml
@@ -3,10 +3,10 @@ link:      https://github.com/guzzle/psr7/security/advisories/GHSA-q7rv-6hp3-vh9
 cve:       CVE-2022-24775
 branches:
     master:
-        time:     2022-03-20 13:44:00
+        time:     2022-03-20 13:45:05
         versions: ['>=2', '<2.1.1']
     1.x:
-        time:     2022-03-20 13:45:00
+        time:     2022-03-20 13:44:44
         versions: ['<1.8.4']
 
 reference: composer://guzzlehttp/psr7

--- a/guzzlehttp/psr7/CVE-2023-29197.yaml
+++ b/guzzlehttp/psr7/CVE-2023-29197.yaml
@@ -3,10 +3,10 @@ link:      https://github.com/guzzle/psr7/security/advisories/GHSA-wxmh-65f7-jcv
 cve:       CVE-2023-29197
 branches:
     master:
-        time:     2023-04-17 16:00:00
+        time:     2023-04-17 16:00:45
         versions: ['>=2', '<2.4.5']
     '1.9':
-        time:     2023-04-17 16:00:00
+        time:     2023-04-17 16:00:37
         versions: ['<1.9.1']
 
 reference: composer://guzzlehttp/psr7

--- a/guzzlehttp/psr7/CVE-2026-48998.yaml
+++ b/guzzlehttp/psr7/CVE-2026-48998.yaml
@@ -1,0 +1,9 @@
+title:     Host confusion via authority reinterpretation
+link:      https://github.com/guzzle/psr7/security/advisories/GHSA-34xg-wgjx-8xph
+cve:       CVE-2026-48998
+branches:
+    '2.10':
+        time:     2026-05-25 22:58:15
+        versions: ['<2.10.2']
+
+reference: composer://guzzlehttp/psr7

--- a/guzzlehttp/psr7/CVE-2026-49214.yaml
+++ b/guzzlehttp/psr7/CVE-2026-49214.yaml
@@ -1,0 +1,9 @@
+title:     CRLF injection via URI host component
+link:      https://github.com/guzzle/psr7/security/advisories/GHSA-hq7v-mx3g-29hw
+cve:       CVE-2026-49214
+branches:
+    '2.10':
+        time:     2026-05-25 22:58:15
+        versions: ['<2.10.2']
+
+reference: composer://guzzlehttp/psr7

--- a/guzzlehttp/psr7/CVE-2026-55766.yaml
+++ b/guzzlehttp/psr7/CVE-2026-55766.yaml
@@ -1,0 +1,9 @@
+title:     CRLF injection in HTTP start-line serialization
+link:      https://github.com/guzzle/psr7/security/advisories/GHSA-vm85-hxw5-5432
+cve:       CVE-2026-55766
+branches:
+    '2.12':
+        time:     2026-06-18 09:49:37
+        versions: ['<2.12.1']
+
+reference: composer://guzzlehttp/psr7


### PR DESCRIPTION
This adds three recently published advisories for guzzlehttp/psr7, CVE-2026-55766 for CRLF injection in HTTP start-line serialization fixed in 2.12.1, and CVE-2026-49214 for CRLF injection via the URI host component and CVE-2026-48998 for host confusion via authority reinterpretation both fixed in 2.10.2. It also aligns the fix dates on the existing guzzlehttp/psr7 entries with the GitHub release creation timestamps.