### PR TITLE
Add guzzlehttp/guzzle-services advisory

### DIFF
--- a/guzzlehttp/guzzle-services/CVE-2026-53723.yaml
+++ b/guzzlehttp/guzzle-services/CVE-2026-53723.yaml
@@ -1,0 +1,9 @@
+title:     XML injection via CDATA terminator in XML request serialization
+link:      https://github.com/guzzle/guzzle-services/security/advisories/GHSA-q8r6-5hfw-5jff
+cve:       CVE-2026-53723
+branches:
+    '1.5':
+        time:     2026-06-02 11:38:10
+        versions: ['<1.5.4']
+
+reference: composer://guzzlehttp/guzzle-services


### PR DESCRIPTION
This adds CVE-2026-53723 for guzzlehttp/guzzle-services, an XML injection issue via a CDATA terminator in XML request serialization that was fixed in 1.5.4.