### PR TITLE
Add guzzlehttp/oauth-subscriber advisory

### DIFF
--- a/guzzlehttp/oauth-subscriber/CVE-2025-21617.yaml
+++ b/guzzlehttp/oauth-subscriber/CVE-2025-21617.yaml
@@ -1,0 +1,9 @@
+title:     Insufficient nonce entropy
+link:      https://github.com/guzzle/oauth-subscriber/security/advisories/GHSA-237r-r8m4-4q88
+cve:       CVE-2025-21617
+branches:
+    '0.8':
+        time:     2025-01-06 19:15:59
+        versions: ['<0.8.1']
+
+reference: composer://guzzlehttp/oauth-subscriber


### PR DESCRIPTION
This adds CVE-2025-21617 for guzzlehttp/oauth-subscriber, an insufficient nonce entropy issue that was fixed in 0.8.1.