### PR TITLE
Fix the CI validation

### DIFF
--- a/matyhtf/framework/CVE-2021-43676.yaml
+++ b/matyhtf/framework/CVE-2021-43676.yaml
@@ -2,6 +2,7 @@ title: Path manipulation
 link: https://github.com/advisories/GHSA-mh9j-v6mq-pfch
 cve: CVE-2021-43676
 reference: composer://matyhtf/framework
+composer-repository: false # package has been deleted: https://packagist.org/transparency-log?actor=&user=&vendor=&package=matyhtf%2Fframework&datetime_from=&datetime_to=
 branches:
     '3.0':
         time: 2022-03-17 16:15:10


### PR DESCRIPTION
The `matyhtf/framework` package has been deleted from Packagist.