### PR TITLE
Add advisory for PHP_CodeSniffer CVE-2026-67434

### DIFF
--- a/squizlabs/php_codesniffer/CVE-2026-67434.yaml
+++ b/squizlabs/php_codesniffer/CVE-2026-67434.yaml
@@ -1,0 +1,11 @@
+title:     OS Command injection
+link:      https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq
+cve:       CVE-2026-67434
+branches:
+    3.x:
+        time:     2026-08-05 23:53:11
+        versions: ['<3.13.6']
+    4.x:
+        time:     2026-08-05 23:53:11
+        versions: ['>=4.0.0', '<4.0.2']
+reference: composer://squizlabs/php_codesniffer


### PR DESCRIPTION
Open question: should old branches, like the `1.5` and `2.9` branches, still be mentioned here ?