### PR TITLE
Remove branch name validation check

### DIFF
--- a/validator.php
+++ b/validator.php
@@ -175,10 +175,6 @@ final class Validate extends Command
                 $upperBoundWithoutLowerBound = null;
 
                 foreach ($data['branches'] as $name => $branch) {
-                    if (!preg_match('/^([\d.\-]+(\.x)?(-dev)?|master|main)$/', $name)) {
-                        $messages[$path][] = sprintf('Invalid branch name "%s".', $name);
-                    }
-
                     if ($keys = array_diff(array_keys($branch), array('time', 'versions'))) {
                         foreach ($keys as $key) {
                             $messages[$path][] = sprintf('Key "%s" is not supported for branch "%s".', $key, $name);


### PR DESCRIPTION
The branch name is not used by the remaining consumers of this dataset, now that fabpot/local-php-security-checker is archived. Restricting the branch name does not provide value anymore and causes issues for packages using a different name for their main release branch.