### PR TITLE
Add a missing CVE ID

### DIFF
--- a/easycorp/easyadmin-bundle/CVE-2026-54087.yaml
+++ b/easycorp/easyadmin-bundle/CVE-2026-54087.yaml
@@ -1,5 +1,6 @@
 title:     Stored Cross-Site Scripting (XSS) via uploaded files served inline in FileField and ImageField
 link:      https://github.com/EasyCorp/EasyAdminBundle/security/advisories/GHSA-8559-gwj3-q37r
+cve:       CVE-2026-54087
 branches:
     5.x:
         time:     2026-06-04 06:43:00


### PR DESCRIPTION
It took GitHub folks some time to assign a CVE ID to this advisory, so it wans't ready when I first submitted this. Adding the CVE ID now.