### PR TITLE
Add seven published guzzlehttp/guzzle advisories

### DIFF
--- a/guzzlehttp/guzzle/CVE-2026-59883.yaml
+++ b/guzzlehttp/guzzle/CVE-2026-59883.yaml
@@ -1,0 +1,9 @@
+title:     Cookie disclosure and injection via IP-address domains
+link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-g446-98w2-8p5w
+cve:       CVE-2026-59883
+branches:
+    '7.12':
+        time:     2026-06-23 15:29:02
+        versions: ['<7.12.3']
+
+reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2026-67339.yaml
+++ b/guzzlehttp/guzzle/CVE-2026-67339.yaml
@@ -1,0 +1,9 @@
+title:     Proxy-Authorization headers can be sent to origin servers
+link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-94pj-82f3-465w
+cve:       CVE-2026-67339
+branches:
+    '7.14':
+        time:     2026-07-14 18:15:01
+        versions: ['<7.14.2']
+
+reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2026-67353.yaml
+++ b/guzzlehttp/guzzle/CVE-2026-67353.yaml
@@ -1,0 +1,9 @@
+title:     Unbounded response cookies risk denial of service
+link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-f283-ghqc-fg79
+cve:       CVE-2026-67353
+branches:
+    '7.15':
+        time:     2026-07-18 11:23:11
+        versions: ['<7.15.1']
+
+reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2026-67354.yaml
+++ b/guzzlehttp/guzzle/CVE-2026-67354.yaml
@@ -1,0 +1,9 @@
+title:     URI fragments disclosed in redirect Referer headers
+link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-h95v-h523-3mw8
+cve:       CVE-2026-67354
+branches:
+    '7.15':
+        time:     2026-07-18 11:23:11
+        versions: ['<7.15.1']
+
+reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2026-67355.yaml
+++ b/guzzlehttp/guzzle/CVE-2026-67355.yaml
@@ -1,0 +1,9 @@
+title:     Host-only cookie scope is not preserved
+link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-wm3w-8rrp-j577
+cve:       CVE-2026-67355
+branches:
+    '7.15':
+        time:     2026-07-18 11:23:11
+        versions: ['<7.15.1']
+
+reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2026-69245.yaml
+++ b/guzzlehttp/guzzle/CVE-2026-69245.yaml
@@ -1,0 +1,12 @@
+title:     Noncanonical cookie domain keeps subdomain scope
+link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-f7vp-7xgx-4w4r
+cve:       CVE-2026-69245
+branches:
+    master:
+        time:     2026-07-26 23:23:24
+        versions: ['>=8', '<8.0.1']
+    '7.15':
+        time:     2026-07-26 23:23:20
+        versions: ['<7.15.2']
+
+reference: composer://guzzlehttp/guzzle

--- a/guzzlehttp/guzzle/CVE-2026-69246.yaml
+++ b/guzzlehttp/guzzle/CVE-2026-69246.yaml
@@ -1,0 +1,12 @@
+title:     Noncanonical host can bypass host-based checks
+link:      https://github.com/guzzle/guzzle/security/advisories/GHSA-v5mv-p594-2x33
+cve:       CVE-2026-69246
+branches:
+    master:
+        time:     2026-07-26 23:23:24
+        versions: ['>=8', '<8.0.1']
+    '7.15':
+        time:     2026-07-26 23:23:20
+        versions: ['<7.15.2']
+
+reference: composer://guzzlehttp/guzzle


### PR DESCRIPTION
Seven guzzlehttp/guzzle advisories with a CVE ID and a public GitHub Security Advisory are not in this database. Affected installs therefore get a clean result from `composer audit` and `local-php-security-checker`.

| CVE | Affected | Summary |
|---|---|---|
| CVE-2026-59883 | `<7.12.3` | Cookie disclosure and injection via IP-address domains |
| CVE-2026-67339 | `<7.14.2` | Proxy-Authorization headers can be sent to origin servers |
| CVE-2026-67353 | `<7.15.1` | Unbounded response cookies risk denial of service |
| CVE-2026-67354 | `<7.15.1` | URI fragments disclosed in redirect Referer headers |
| CVE-2026-67355 | `<7.15.1` | Host-only cookie scope is not preserved |
| CVE-2026-69245 | `<7.15.2`, `>=8 <8.0.1` | Noncanonical cookie domain keeps subdomain scope |
| CVE-2026-69246 | `<7.15.2`, `>=8 <8.0.1` | Noncanonical host can bypass host-based checks |

All were published upstream between 2026-07-20 and 2026-08-03. The two Guzzle advisories from June (CVE-2026-55568, CVE-2026-55767) are already here and landed on their publication day, so this looks like a gap rather than a deliberate omission — but please say so if these are excluded on purpose and I will drop the PR.

**Sources.** Version ranges come from the GitHub advisories, unchanged. Branch timestamps are the packagist release times of the first patched version, which is the convention the existing files follow: CVE-2026-55767 carries `2026-06-18 14:12:49`, and that is exactly what packagist reports for 7.12.1.

`validator.php` reports no issues for each of the seven files.

Happy to split this into one PR per advisory if that is easier to review.