### PR TITLE
Add 14 published advisories across seven packages

### DIFF
--- a/filp/whoops/CVE-2017-16880.yaml
+++ b/filp/whoops/CVE-2017-16880.yaml
@@ -1,0 +1,9 @@
+title:     Cross-site scripting in the template helper
+link:      https://github.com/advisories/GHSA-2jjm-6whx-p8w4
+cve:       CVE-2017-16880
+branches:
+    '2.1':
+        time:     2017-11-17 08:15:51
+        versions: ['<2.1.13']
+
+reference: composer://filp/whoops

--- a/guzzlehttp/psr7/CVE-2026-59882.yaml
+++ b/guzzlehttp/psr7/CVE-2026-59882.yaml
@@ -1,0 +1,9 @@
+title:     Host confusion via weak URI host validation
+link:      https://github.com/guzzle/psr7/security/advisories/GHSA-c2w2-prh8-qm98
+cve:       CVE-2026-59882
+branches:
+    '2.12':
+        time:     2026-06-23 15:21:08
+        versions: ['<2.12.3']
+
+reference: composer://guzzlehttp/psr7

--- a/laravel/framework/CVE-2020-19316.yaml
+++ b/laravel/framework/CVE-2020-19316.yaml
@@ -1,0 +1,9 @@
+title:     OS command injection in Filesystem::link on Windows
+link:      https://github.com/advisories/GHSA-w2pm-r78h-4m7v
+cve:       CVE-2020-19316
+branches:
+    '5.8':
+        time:     2019-05-14 16:02:41
+        versions: ['<5.8.17']
+
+reference: composer://laravel/framework

--- a/laravel/framework/CVE-2025-27515.yaml
+++ b/laravel/framework/CVE-2025-27515.yaml
@@ -1,0 +1,15 @@
+title:     File validation bypass with wildcard rules
+link:      https://github.com/laravel/framework/security/advisories/GHSA-78fx-h6xr-vch4
+cve:       CVE-2025-27515
+branches:
+    '12.1':
+        time:     2025-03-05 15:31:19
+        versions: ['>=12.0.0', '<12.1.1']
+    '11.44':
+        time:     2025-03-05 15:34:10
+        versions: ['>=11.0.0', '<11.44.1']
+    '10.48':
+        time:     2025-03-12 14:42:01
+        versions: ['<10.48.29']
+
+reference: composer://laravel/framework

--- a/league/commonmark/CVE-2025-46734.yaml
+++ b/league/commonmark/CVE-2025-46734.yaml
@@ -1,0 +1,9 @@
+title:     XSS vulnerability in the Attributes extension
+link:      https://github.com/thephpleague/commonmark/security/advisories/GHSA-3527-qv2q-pfvx
+cve:       CVE-2025-46734
+branches:
+    '2.7':
+        time:     2025-05-05 12:20:28
+        versions: ['>=1.5.0', '<2.7.0']
+
+reference: composer://league/commonmark

--- a/league/commonmark/CVE-2026-30838.yaml
+++ b/league/commonmark/CVE-2026-30838.yaml
@@ -1,0 +1,9 @@
+title:     DisallowedRawHtml bypass via whitespace in HTML tag names
+link:      https://github.com/thephpleague/commonmark/security/advisories/GHSA-4v6x-c7xx-hw9f
+cve:       CVE-2026-30838
+branches:
+    '2.8':
+        time:     2026-03-05 21:37:03
+        versions: ['>=2.0.0', '<2.8.1']
+
+reference: composer://league/commonmark

--- a/league/commonmark/CVE-2026-33347.yaml
+++ b/league/commonmark/CVE-2026-33347.yaml
@@ -1,0 +1,9 @@
+title:     Embed extension allowed_domains bypass
+link:      https://github.com/thephpleague/commonmark/security/advisories/GHSA-hh8v-hgvp-g3f5
+cve:       CVE-2026-33347
+branches:
+    '2.8':
+        time:     2026-03-19 13:16:38
+        versions: ['>=2.3.0', '<2.8.2']
+
+reference: composer://league/commonmark

--- a/league/commonmark/CVE-2026-71478.yaml
+++ b/league/commonmark/CVE-2026-71478.yaml
@@ -1,0 +1,9 @@
+title:     AttributesExtension href/src unsafe-link filter bypass
+link:      https://github.com/thephpleague/commonmark/security/advisories/GHSA-29pj-957v-52mc
+cve:       CVE-2026-71478
+branches:
+    '2.9':
+        time:     2026-08-03 13:42:31
+        versions: ['>=1.5.0', '<2.9.0']
+
+reference: composer://league/commonmark

--- a/league/commonmark/CVE-2026-71488.yaml
+++ b/league/commonmark/CVE-2026-71488.yaml
@@ -1,0 +1,9 @@
+title:     Quadratic-time denial of service when parsing crafted Markdown
+link:      https://github.com/thephpleague/commonmark/security/advisories/GHSA-2q4p-g7hv-5rgv
+cve:       CVE-2026-71488
+branches:
+    '2.9':
+        time:     2026-08-03 13:42:31
+        versions: ['>=0.6.0', '<2.9.0']
+
+reference: composer://league/commonmark

--- a/livewire/livewire/CVE-2024-21504.yaml
+++ b/livewire/livewire/CVE-2024-21504.yaml
@@ -1,0 +1,9 @@
+title:     Cross-site scripting via a property bound with the Url attribute
+link:      https://github.com/advisories/GHSA-389c-cf87-qmwj
+cve:       CVE-2024-21504
+branches:
+    '3.4':
+        time:     2024-03-14 14:03:32
+        versions: ['>=3.3.5', '<3.4.9']
+
+reference: composer://livewire/livewire

--- a/livewire/livewire/CVE-2024-47823.yaml
+++ b/livewire/livewire/CVE-2024-47823.yaml
@@ -1,0 +1,12 @@
+title:     Remote code execution on file uploads
+link:      https://github.com/livewire/livewire/security/advisories/GHSA-f3cx-396f-7jqp
+cve:       CVE-2024-47823
+branches:
+    '3.5':
+        time:     2024-07-03 17:22:45
+        versions: ['>=3.0.0-beta1', '<3.5.2']
+    '2.12':
+        time:     2024-07-03 15:52:04
+        versions: ['<2.12.7']
+
+reference: composer://livewire/livewire

--- a/livewire/livewire/CVE-2025-54068.yaml
+++ b/livewire/livewire/CVE-2025-54068.yaml
@@ -1,0 +1,9 @@
+title:     Remote code execution during component property hydration
+link:      https://github.com/livewire/livewire/security/advisories/GHSA-29cq-5w36-x7w3
+cve:       CVE-2025-54068
+branches:
+    '3.6':
+        time:     2025-07-17 05:12:15
+        versions: ['>=3.0.0-beta1', '<3.6.4']
+
+reference: composer://livewire/livewire

--- a/nesbot/carbon/CVE-2025-22145.yaml
+++ b/nesbot/carbon/CVE-2025-22145.yaml
@@ -1,0 +1,12 @@
+title:     Arbitrary file include via unvalidated input to setLocale
+link:      https://github.com/CarbonPHP/carbon/security/advisories/GHSA-j3f9-p6hm-5w6q
+cve:       CVE-2025-22145
+branches:
+    '3.8':
+        time:     2024-12-27 09:25:35
+        versions: ['>=3.0.0', '<3.8.4']
+    '2.72':
+        time:     2024-12-27 09:28:11
+        versions: ['<2.72.6']
+
+reference: composer://nesbot/carbon

--- a/psy/psysh/CVE-2026-25129.yaml
+++ b/psy/psysh/CVE-2026-25129.yaml
@@ -1,0 +1,12 @@
+title:     Local privilege escalation via .psysh.php auto-load from the working directory
+link:      https://github.com/bobthecow/psysh/security/advisories/GHSA-4486-gxhx-5mg7
+cve:       CVE-2026-25129
+branches:
+    '0.12':
+        time:     2026-01-30 17:33:13
+        versions: ['>=0.12.0', '<0.12.19']
+    '0.11':
+        time:     2026-01-30 05:01:10
+        versions: ['<0.11.23']
+
+reference: composer://psy/psysh


### PR DESCRIPTION
Follow-up to #809, from the same sweep — that one covered guzzlehttp/guzzle, this covers the rest. Happy to have either one split per package if that reviews better.

Each entry has a CVE ID and is acknowledged upstream: **eleven** through a project security advisory, **three** through a fix commit in the project's own repository. None is in this database, so `composer audit` and `local-php-security-checker` return a clean result for affected installs.

| Package | CVE | Affected | Summary |
|---|---|---|---|
| filp/whoops | CVE-2017-16880 | `<2.1.13` | XSS in the template helper |
| guzzlehttp/psr7 | CVE-2026-59882 | `<2.12.3` | Host confusion via weak URI host validation |
| laravel/framework | CVE-2020-19316 | `<5.8.17` | OS command injection in `Filesystem::link` |
| laravel/framework | CVE-2025-27515 | 10.x, 11.x, 12.x | File validation bypass with wildcard rules |
| league/commonmark | CVE-2025-46734 | `<2.7.0` | XSS in the Attributes extension |
| league/commonmark | CVE-2026-30838 | `<2.8.1` | DisallowedRawHtml bypass via whitespace in tag names |
| league/commonmark | CVE-2026-33347 | `<2.8.2` | Embed extension `allowed_domains` bypass |
| league/commonmark | CVE-2026-71478 | `<2.9.0` | AttributesExtension unsafe-link filter bypass |
| league/commonmark | CVE-2026-71488 | `<2.9.0` | Quadratic-time denial of service |
| livewire/livewire | CVE-2024-21504 | `<3.4.9` | XSS via a `Url`-bound property |
| livewire/livewire | CVE-2024-47823 | 2.x, 3.x | RCE on file uploads |
| livewire/livewire | CVE-2025-54068 | `<3.6.4` | RCE during component property hydration |
| nesbot/carbon | CVE-2025-22145 | 2.x, 3.x | Arbitrary file include via `setLocale` |
| psy/psysh | CVE-2026-25129 | 0.11.x, 0.12.x | Local privilege escalation via `.psysh.php` |

`filp/whoops`, `nesbot/carbon` and `psy/psysh` have no directory here yet.

**Three entries rest on a fix commit rather than a project advisory** — CVE-2017-16880 (`c16791d`, *"TemplateHelper: fix XSS if Symfony dumper is not available"*), CVE-2020-19316 (`44c3feb`, *"use escapeshellarg on windows symlink"*) and CVE-2024-21504 (`c65b3f0`, *"patch vulnerability (#8117)"*). If that is not the bar you want for an entry, say so and I will drop those three.

**Two things I deliberately left out**, in case you would have expected them:

- **CVE-2019-9081** (laravel/framework). Its only project-side reference is a discussion titled *"Questions regarding old CVEs"* with no replies; the substance is a gadget-chain writeup on a personal blog. That did not look like something to add on someone else's behalf.
- **CVE-2026-24739** (symfony/process). The Symfony entries here follow their own shape — per-minor branches including unmaintained ones with `time: ~`, links to `symfony.com/cve-…`, and identical timestamps across branches. That reads as a process you already have, so a drive-by PR seemed more likely to collide with it than to help.

**Sources.** Version ranges are taken from the GitHub advisories unchanged, except where the upper bound was inclusive: `validator.php` requires an exclusive bound naming the release that ships the patch, so `<=2.8.0` with a fix in 2.8.1 is written `<2.8.1`. Branch timestamps are the packagist release times of the first patched version, matching the existing convention.

`validator.php` reports no issues for each file, and **no issues over all 1611 advisories** with these applied.