### PR TITLE
Add security advisories for TYPO3 extensions (August 2026 releases)

### DIFF
--- a/apache-solr-for-typo3/solr/CVE-2026-56092.yaml
+++ b/apache-solr-for-typo3/solr/CVE-2026-56092.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-025: Broken Access Control in extension "Apache Solr for TYPO3 - Enterprise Search" (solr)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-025'
+cve: CVE-2026-56092
+branches:
+    13.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=13.0.0', '<13.1.4']
+    12.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=12.0.0', '<12.1.4']
+    11.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<11.6.6']
+reference: 'composer://apache-solr-for-typo3/solr'

--- a/apache-solr-for-typo3/solr/CVE-2026-56093.yaml
+++ b/apache-solr-for-typo3/solr/CVE-2026-56093.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-025: Broken Access Control in extension "Apache Solr for TYPO3 - Enterprise Search" (solr)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-025'
+cve: CVE-2026-56093
+branches:
+    13.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=13.0.0', '<13.1.4']
+    12.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=12.0.0', '<12.1.4']
+    11.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<11.6.6']
+reference: 'composer://apache-solr-for-typo3/solr'

--- a/apache-solr-for-typo3/solr/CVE-2026-56094.yaml
+++ b/apache-solr-for-typo3/solr/CVE-2026-56094.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-025: Information Disclosure in extension "Apache Solr for TYPO3 - Enterprise Search" (solr)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-025'
+cve: CVE-2026-56094
+branches:
+    13.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=13.0.0', '<13.1.4']
+    12.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=12.0.0', '<12.1.4']
+    11.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<11.6.6']
+reference: 'composer://apache-solr-for-typo3/solr'

--- a/apache-solr-for-typo3/solr/CVE-2026-56095.yaml
+++ b/apache-solr-for-typo3/solr/CVE-2026-56095.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-025: Insecure Deserialization in extension "Apache Solr for TYPO3 - Enterprise Search" (solr)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-025'
+cve: CVE-2026-56095
+branches:
+    13.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=13.0.0', '<13.1.4']
+    12.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=12.0.0', '<12.1.4']
+    11.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<11.6.6']
+reference: 'composer://apache-solr-for-typo3/solr'

--- a/apache-solr-for-typo3/solr/CVE-2026-56096.yaml
+++ b/apache-solr-for-typo3/solr/CVE-2026-56096.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-025: Information Disclosure in extension "Apache Solr for TYPO3 - Enterprise Search" (solr)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-025'
+cve: CVE-2026-56096
+branches:
+    13.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=13.0.0', '<13.1.4']
+    12.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=12.0.0', '<12.1.4']
+    11.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<11.6.6']
+reference: 'composer://apache-solr-for-typo3/solr'

--- a/codingms/modules/CVE-2026-77127.yaml
+++ b/codingms/modules/CVE-2026-77127.yaml
@@ -1,0 +1,11 @@
+title: 'TYPO3-EXT-SA-2026-016: Information Disclosure in extension "Modules" (modules)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-016'
+cve: CVE-2026-77127
+branches:
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=8.0.0', '<8.1.4']
+    7.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<7.10.4']
+reference: 'composer://codingms/modules'

--- a/derhansen/sf_event_mgt/CVE-2026-77128.yaml
+++ b/derhansen/sf_event_mgt/CVE-2026-77128.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-EXT-SA-2026-023: Broken Access Control in extension "Event management and registration" (sf_event_mgt)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-023'
+cve: CVE-2026-77128
+branches:
+    9.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=9.0.0', '<9.0.3']
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=8.0.0', '<8.6.2']
+    7.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=7.0.0', '<7.9.3']
+    6.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=6.0.0', '<6.7.2']
+    5.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<5.9.3']
+reference: 'composer://derhansen/sf_event_mgt'

--- a/derhansen/sf_event_mgt/CVE-2026-77129.yaml
+++ b/derhansen/sf_event_mgt/CVE-2026-77129.yaml
@@ -1,0 +1,20 @@
+title: 'TYPO3-EXT-SA-2026-023: Server-Side Template Injection in extension "Event management and registration" (sf_event_mgt)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-023'
+cve: CVE-2026-77129
+branches:
+    9.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=9.0.0', '<9.0.3']
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=8.0.0', '<8.6.2']
+    7.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=7.0.0', '<7.9.3']
+    6.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=6.0.0', '<6.7.2']
+    5.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<5.9.3']
+reference: 'composer://derhansen/sf_event_mgt'

--- a/frappant/frp-form-answers/CVE-2026-77137.yaml
+++ b/frappant/frp-form-answers/CVE-2026-77137.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-027: SQL Injection in extension "Forms Export" (frp_form_answers)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-027'
+cve: CVE-2026-77137
+branches:
+    7.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=7.0.0', '<7.1.1']
+    6.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=6.0.0', '<6.1.3']
+    5.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<5.0.5']
+reference: 'composer://frappant/frp-form-answers'

--- a/in2code/femanager/CVE-2026-77133.yaml
+++ b/in2code/femanager/CVE-2026-77133.yaml
@@ -1,0 +1,17 @@
+title: 'TYPO3-EXT-SA-2026-024: Broken Access Control in extension "femanager" (femanager)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-024'
+cve: CVE-2026-77133
+branches:
+    13.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=13.0.0', '<13.3.5']
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=8.0.0', '<8.4.2']
+    7.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=7.0.0', '<7.5.5']
+    6.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<6.4.5']
+reference: 'composer://in2code/femanager'

--- a/in2code/femanager/CVE-2026-77134.yaml
+++ b/in2code/femanager/CVE-2026-77134.yaml
@@ -1,0 +1,17 @@
+title: 'TYPO3-EXT-SA-2026-024: Broken Access Control in extension "femanager" (femanager)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-024'
+cve: CVE-2026-77134
+branches:
+    13.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=13.0.0', '<13.3.5']
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=8.0.0', '<8.4.2']
+    7.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=7.0.0', '<7.5.5']
+    6.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<6.4.5']
+reference: 'composer://in2code/femanager'

--- a/in2code/femanager/CVE-2026-77135.yaml
+++ b/in2code/femanager/CVE-2026-77135.yaml
@@ -1,0 +1,17 @@
+title: 'TYPO3-EXT-SA-2026-024: Information Disclosure in extension "femanager" (femanager)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-024'
+cve: CVE-2026-77135
+branches:
+    13.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=13.0.0', '<13.3.5']
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=8.0.0', '<8.4.2']
+    7.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=7.0.0', '<7.5.5']
+    6.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<6.4.5']
+reference: 'composer://in2code/femanager'

--- a/in2code/femanager/CVE-2026-77146.yaml
+++ b/in2code/femanager/CVE-2026-77146.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-024: Broken Access Control in extension "femanager" (femanager)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-024'
+cve: CVE-2026-77146
+branches:
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=8.0.0', '<8.4.2']
+reference: 'composer://in2code/femanager'

--- a/in2code/powermail/CVE-2026-77136.yaml
+++ b/in2code/powermail/CVE-2026-77136.yaml
@@ -1,0 +1,14 @@
+title: 'TYPO3-EXT-SA-2026-022: Server-Side Template Injection in extension "powermail" (powermail)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-022'
+cve: CVE-2026-77136
+branches:
+    master:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=13.0.0', '<13.2.1']
+    12.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=11.0.0', '<12.6.1']
+    10.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<10.9.3']
+reference: 'composer://in2code/powermail'

--- a/jweiland/clubdirectory/CVE-2026-77141.yaml
+++ b/jweiland/clubdirectory/CVE-2026-77141.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-019: Broken Access Control in extension "Club Directory" (clubdirectory)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-019'
+cve: CVE-2026-77141
+branches:
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<8.1.3']
+reference: 'composer://jweiland/clubdirectory'

--- a/jweiland/events2/CVE-2026-77144.yaml
+++ b/jweiland/events2/CVE-2026-77144.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-026: Broken Access Control in extension "Events 2" (events2)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-026'
+cve: CVE-2026-77144
+branches:
+    10.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<10.2.12']
+reference: 'composer://jweiland/events2'

--- a/jweiland/events2/CVE-2026-77145.yaml
+++ b/jweiland/events2/CVE-2026-77145.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-026: Broken Access Control in extension "Events 2" (events2)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-026'
+cve: CVE-2026-77145
+branches:
+    10.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<10.2.12']
+reference: 'composer://jweiland/events2'

--- a/jweiland/pforum/CVE-2026-77143.yaml
+++ b/jweiland/pforum/CVE-2026-77143.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-021: Broken Access Control in extension "Forum" (pforum)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-021'
+cve: CVE-2026-77143
+branches:
+    6.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<6.2.4']
+reference: 'composer://jweiland/pforum'

--- a/jweiland/telephonedirectory/CVE-2026-77140.yaml
+++ b/jweiland/telephonedirectory/CVE-2026-77140.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-018: Broken Access Control in extension "Telephone Directory" (telephonedirectory)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-018'
+cve: CVE-2026-77140
+branches:
+    6.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<6.2.0']
+reference: 'composer://jweiland/telephonedirectory'

--- a/jweiland/yellowpages2/CVE-2026-77142.yaml
+++ b/jweiland/yellowpages2/CVE-2026-77142.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-020: Broken Access Control in extension "Industry Directory" (yellowpages2)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-020'
+cve: CVE-2026-77142
+branches:
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<8.1.2']
+reference: 'composer://jweiland/yellowpages2'

--- a/lochmueller/html5videoplayer-powermail/CVE-2026-77138.yaml
+++ b/lochmueller/html5videoplayer-powermail/CVE-2026-77138.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-014: Remote Code Execution in extension "HTML5 Video Player vs. Powermail" (html5videoplayer_powermail)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-014'
+cve: CVE-2026-77138
+branches:
+    main:
+        time: ~
+        versions: ['<=0.2.1']
+reference: 'composer://lochmueller/html5videoplayer-powermail'

--- a/mask/mask/CVE-2026-77139.yaml
+++ b/mask/mask/CVE-2026-77139.yaml
@@ -1,0 +1,11 @@
+title: 'TYPO3-EXT-SA-2026-017: Path Traversal in extension "Mask" (mask)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-017'
+cve: CVE-2026-77139
+branches:
+    9.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['>=9.0.0', '<9.0.11']
+    8.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<8.3.12']
+reference: 'composer://mask/mask'

--- a/syssy/syssy-typo3-extension/CVE-2026-77130.yaml
+++ b/syssy/syssy-typo3-extension/CVE-2026-77130.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-015: Insufficient Session Expiration in extension "SYSSY - TYPO3 Monitoring & Security Checks" (syssy)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-015'
+cve: CVE-2026-77130
+branches:
+    3.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<3.0.6']
+reference: 'composer://syssy/syssy-typo3-extension'

--- a/syssy/syssy-typo3-extension/CVE-2026-77131.yaml
+++ b/syssy/syssy-typo3-extension/CVE-2026-77131.yaml
@@ -1,0 +1,8 @@
+title: 'TYPO3-EXT-SA-2026-015: Cleartext Transmission of Sensitive Information in extension "SYSSY - TYPO3 Monitoring & Security Checks" (syssy)'
+link: 'https://news.typo3.com/security/advisory/typo3-ext-sa-2026-015'
+cve: CVE-2026-77131
+branches:
+    3.x:
+        time: '2026-08-25 09:00:00'
+        versions: ['<3.0.6']
+reference: 'composer://syssy/syssy-typo3-extension'


### PR DESCRIPTION
Adds 24 new advisories covering 14 TYPO3 extension security bulletins (TYPO3-EXT-SA-2026-014 through -027).

| Advisory                                                                                | Extension                                                       | Vulnerability                                                                    | CVEs                                                                           |
|-----------------------------------------------------------------------------------------|-----------------------------------------------------------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
| [TYPO3-EXT-SA-2026-014](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-014) | HTML5 Video Player vs. Powermail (`html5videoplayer_powermail`) | Remote Code Execution                                                            | CVE-2026-77138                                                                 |
| [TYPO3-EXT-SA-2026-015](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-015) | SYSSY (`syssy`)                                                 | Insufficient Session Expiration, Cleartext Transmission of Sensitive Information | CVE-2026-77130, CVE-2026-77131                                                 |
| [TYPO3-EXT-SA-2026-016](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-016) | Modules (`modules`)                                             | Information Disclosure                                                           | CVE-2026-77127                                                                 |
| [TYPO3-EXT-SA-2026-017](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-017) | Mask (`mask`)                                                   | Path Traversal                                                                   | CVE-2026-77139                                                                 |
| [TYPO3-EXT-SA-2026-018](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-018) | Telephone Directory (`telephonedirectory`)                      | Broken Access Control                                                            | CVE-2026-77140                                                                 |
| [TYPO3-EXT-SA-2026-019](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-019) | Club Directory (`clubdirectory`)                                | Broken Access Control                                                            | CVE-2026-77141                                                                 |
| [TYPO3-EXT-SA-2026-020](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-020) | Industry Directory (`yellowpages2`)                             | Broken Access Control                                                            | CVE-2026-77142                                                                 |
| [TYPO3-EXT-SA-2026-021](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-021) | Forum (`pforum`)                                                | Broken Access Control                                                            | CVE-2026-77143                                                                 |
| [TYPO3-EXT-SA-2026-022](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-022) | powermail (`powermail`)                                         | Server-Side Template Injection                                                   | CVE-2026-77136                                                                 |
| [TYPO3-EXT-SA-2026-023](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-023) | Event management and registration (`sf_event_mgt`)              | Broken Access Control, Server-Side Template Injection                            | CVE-2026-77128, CVE-2026-77129                                                 |
| [TYPO3-EXT-SA-2026-024](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-024) | femanager (`femanager`)                                         | Broken Access Control, Information Disclosure                                    | CVE-2026-77133, CVE-2026-77134, CVE-2026-77135, CVE-2026-77146                 |
| [TYPO3-EXT-SA-2026-025](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-025) | Apache Solr for TYPO3 - Enterprise Search (`solr`)              | Broken Access Control, Information Disclosure, Insecure Deserialization          | CVE-2026-56092, CVE-2026-56093, CVE-2026-56094, CVE-2026-56095, CVE-2026-56096 |
| [TYPO3-EXT-SA-2026-026](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-026) | Events 2 (`events2`)                                            | Broken Access Control                                                            | CVE-2026-77144, CVE-2026-77145                                                 |
| [TYPO3-EXT-SA-2026-027](https://news.typo3.com/security/advisory/typo3-ext-sa-2026-027) | Forms Export (`frp_form_answers`)                               | SQL Injection                                                                    | CVE-2026-77137                                                                 |
