### PR TITLE
Add Azure Storage mappings for CVE-2016-5385

### DIFF
--- a/microsoft/azure-storage-common/CVE-2016-5385.yaml
+++ b/microsoft/azure-storage-common/CVE-2016-5385.yaml
@@ -1,0 +1,8 @@
+title: 'HTTP Proxy header vulnerability'
+link: 'https://github.com/advisories/GHSA-m6ch-gg5f-wxx3'
+cve: CVE-2016-5385
+branches:
+    1.x:
+        time: null
+        versions: ['>=1.0.0', '<=1.5.2']
+reference: 'composer://microsoft/azure-storage-common'

--- a/microsoft/azure-storage/CVE-2016-5385.yaml
+++ b/microsoft/azure-storage/CVE-2016-5385.yaml
@@ -1,0 +1,8 @@
+title: 'HTTP Proxy header vulnerability'
+link: 'https://github.com/advisories/GHSA-m6ch-gg5f-wxx3'
+cve: CVE-2016-5385
+branches:
+    0.x:
+        time: null
+        versions: ['>=0.15.0', '<=0.19.1']
+reference: 'composer://microsoft/azure-storage'


### PR DESCRIPTION
Adds mappings for CVE-2016-5385 (httpoxy) to `microsoft/azure-storage` and `microsoft/azure-storage-common`.
These packages directly read `getenv('HTTP_PROXY')` and pass it to Guzzle as an explicit client option in [`ServiceRestProxy::createClient()`](https://github.com/Azure/azure-storage-php/blob/0bf4c5ca71819d44030189b2897d041116f9f493/src/Common/Internal/ServiceRestProxy.php#L99-L109), bypassing Guzzle's built-in httpoxy protection.
**Affected versions:**
- `microsoft/azure-storage`: `>=0.15.0,<=0.19.1`
- `microsoft/azure-storage-common`: `>=1.0.0,<=1.5.2`
Upstream is archived and was never patched.
