### PR TITLE
Correct the two `react/http` advisories for `v1.11.1` to their correct version targetting

### DIFF
--- a/react/http/CVE-2026-84997.yaml
+++ b/react/http/CVE-2026-84997.yaml
@@ -4,5 +4,5 @@ cve: CVE-2026-84997
 branches:
     1.x:
         time: 2026-09-09 09:11:00
-        versions: ['>=0.6.0', '<1.11.0']
+        versions: ['>=0.6.0', '<1.11.1']
 reference: composer://react/http

--- a/react/http/GHSA-g4f2-2pf3-2pwj.yaml
+++ b/react/http/GHSA-g4f2-2pf3-2pwj.yaml
@@ -3,5 +3,5 @@ link: https://github.com/reactphp/http/security/advisories/GHSA-g4f2-2pf3-2pwj
 branches:
     1.x:
         time: 2026-09-09 09:11:00
-        versions: ['>=1.0.0', '<1.11.0']
+        versions: ['>=1.0.0', '<1.11.1']
 reference: composer://react/http


### PR DESCRIPTION
Forgot to add the `=` in `<=1.11.0`.