### PR TITLE
Remove local checker README reference in favour of composer audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ into the public domain.
 Checking for Vulnerabilities
 ----------------------------
 
-To check for vulnerabilities in your applications beside manual checks, you should
-use the [Local CLI tool][1]:
+To check your application's dependencies for known vulnerabilities, run
+[`composer audit`][1] from your project's root directory (the directory containing
+`composer.json` and `composer.lock`):
 
-        local-php-security-checker --path=/path/to/composer.lock
-
-**TIP**: If you are using Github, you can use the PHP Security Checker [Github
-Action][2] to automatically check for vulnerabilities when pushing code.
+```sh
+composer audit
+```
 
 Contributing
 ------------
@@ -75,5 +75,5 @@ If some affected code is available through different Composer entries (like
 when you have read-only subtree splits of a main repository), duplicate the
 information in several files.
 
-[1]: https://github.com/fabpot/local-php-security-checker
+[1]: https://getcomposer.org/doc/03-cli.md#audit
 [2]: https://github.com/marketplace/actions/the-php-security-checker


### PR DESCRIPTION
As per @stof review comment: Instead of cleaning up the scaping in the readme: Remove the local checker reference in favour of composer audit.


<details><summary>Old PR descripton</summary>
Fix the spacing before the code snippet, currently it as an extra indent:

<img width="864" height="891" alt="Screenshot_20260911-092947~2" src="https://github.com/user-attachments/assets/2466199c-9713-4b0c-99ab-61258586e8bc" />
</details>